### PR TITLE
fix(webui): Use sensible default timeout

### DIFF
--- a/web/src/api/apiKeys.ts
+++ b/web/src/api/apiKeys.ts
@@ -8,7 +8,7 @@ interface ApiKey {
 
 const client = createClient({
   baseURL: "/v1/api/authorities",
-  timeout: 120,
+  timeout: 120000,
 });
 
 const actions = {

--- a/web/src/api/artifacts.ts
+++ b/web/src/api/artifacts.ts
@@ -26,7 +26,7 @@ const createDateAttributes = (artifact: Artifact): Artifact => {
 
 const client = createClient({
   baseURL: "/v1/api/artifacts",
-  timeout: 120,
+  timeout: 120000,
 });
 
 const setDateAttributes = (r: Result<Artifact[]> | Result<Artifact>): Result<Artifact[]> | Result<Artifact> => {

--- a/web/src/api/authorities.ts
+++ b/web/src/api/authorities.ts
@@ -13,7 +13,7 @@ interface Authority {
 
 const client = createClient({
   baseURL: "/v1/api/authorities",
-  timeout: 120,
+  timeout: 120000,
 });
 
 const actions = {

--- a/web/src/api/keys.ts
+++ b/web/src/api/keys.ts
@@ -10,7 +10,7 @@ interface Key {
 
 const client = createClient({
   baseURL: "/v1/api/authorities",
-  timeout: 120,
+  timeout: 120000,
 });
 
 const actions = {


### PR DESCRIPTION
Axios timeout is specified in number of milliseconds.

It may be hard to make timeouts configurable, because web UI needs to be rebuilt on change, and getting configuration from the server would be affected by the timeout itself.

We should ship a release with sensible defaults first, and then consider how to make it configurable.