### PR TITLE
 fix(github): Fallback to user's login name

### DIFF
--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -132,16 +132,12 @@ func (p *Provider) PerformUserNameRequest(t tokenResponse) (string, error) {
 		return "", err
 	}
 
-	if name, ok := data["name"]; ok {
-		if nameStr, ok := name.(string); ok {
-			return nameStr, nil
-		}
+	if name, ok := data["name"].(string); ok {
+		return name, nil
 	}
 
-	if login, ok := data["login"]; ok {
-		if loginStr, ok := login.(string); ok {
-			return loginStr, nil
-		}
+	if login, ok := data["login"].(string); ok {
+		return login, nil
 	}
 
 	return "", fmt.Errorf("could not get the user or login name")

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -132,7 +132,19 @@ func (p *Provider) PerformUserNameRequest(t tokenResponse) (string, error) {
 		return "", err
 	}
 
-	return data["name"].(string), nil
+	if name, ok := data["name"]; ok {
+		if nameStr, ok := name.(string); ok {
+			return nameStr, nil
+		}
+	}
+
+	if login, ok := data["login"]; ok {
+		if loginStr, ok := login.(string); ok {
+			return loginStr, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not get the user or login name")
 }
 
 func (p *Provider) PerformUserEmailRequest(t tokenResponse) (string, error) {


### PR DESCRIPTION
On GitHub, the user's name is optional. If the user's name is not available, we should fallback and use the user's login name (username) instead.

Closes #192.