### PR TITLE
fix: Modules and providers names case insensitive

### DIFF
--- a/internal/server/repositories/module.go
+++ b/internal/server/repositories/module.go
@@ -43,10 +43,11 @@ func (r *DefaultModuleRepository) Find(namespace, name, provider string) (*modul
 	mtn := (module.Module{}).TableName()
 
 	err := r.Database.Handler().
-		Where(module.Module{
-			Name:     name,
-			Provider: provider,
-		}).
+		Where(
+			fmt.Sprintf("%s.name = LOWER(?) AND %s.provider = LOWER(?)", mtn, mtn),
+			name,
+			provider,
+		).
 		Joins(
 			fmt.Sprintf(
 				"JOIN %s ON %s.id = %s.authority_id AND LOWER(%s.name) = LOWER(?)",

--- a/internal/server/repositories/module.go
+++ b/internal/server/repositories/module.go
@@ -44,7 +44,7 @@ func (r *DefaultModuleRepository) Find(namespace, name, provider string) (*modul
 
 	err := r.Database.Handler().
 		Where(
-			fmt.Sprintf("%s.name = LOWER(?) AND %s.provider = LOWER(?)", mtn, mtn),
+			fmt.Sprintf("LOWER(%s.name) = LOWER(?) AND LOWER(%s.provider) = LOWER(?)", mtn, mtn),
 			name,
 			provider,
 		).

--- a/internal/server/repositories/provider.go
+++ b/internal/server/repositories/provider.go
@@ -45,7 +45,7 @@ func (r *DefaultProviderRepository) Find(namespace, name string) (*provider.Prov
 
 	err := r.Database.Handler().
 		Where(
-			fmt.Sprintf("%s.name = LOWER(?)", ptn),
+			fmt.Sprintf("LOWER(%s.name) = LOWER(?)", ptn),
 			name,
 		).
 		Joins(

--- a/internal/server/repositories/provider.go
+++ b/internal/server/repositories/provider.go
@@ -44,9 +44,10 @@ func (r *DefaultProviderRepository) Find(namespace, name string) (*provider.Prov
 	ptn := (provider.Provider{}).TableName()
 
 	err := r.Database.Handler().
-		Where(provider.Provider{
-			Name: name,
-		}).
+		Where(
+			fmt.Sprintf("%s.name = LOWER(?)", ptn),
+			name,
+		).
 		Joins(
 			fmt.Sprintf(
 				"JOIN %s ON %s.id = %s.authority_id AND LOWER(%s.name) = LOWER(?)",

--- a/web/src/pages/Artifact.svelte
+++ b/web/src/pages/Artifact.svelte
@@ -14,9 +14,9 @@
 {#key params}
   <Artifact
     type={params.provider ? "module" : "provider"}
-    namespace={params.namespace}
-    name={params.name}
-    provider={params.provider}
+    namespace={params.namespace.toLowerCase()}
+    name={params.name.toLowerCase()}
+    provider={params.provider.toLowerCase()}
     version={params.version}
   />
 {/key}


### PR DESCRIPTION
This PR fixes the bug where artifacts that contains some upper-case letters in their name were not discoverable by the API.

To avoid creating a breaking change, I updated the find methods to convert the inputs to lowercase before comparing them with the values stored in the database. A more efficient approach would be to assume that everything in the database is lowercased, and lowercase the names during the creation of the modules/providers. The latter might be subject for a different PR and released in a future minor version.

Fixes #191.