### PR TITLE
fix(webui): Malfunction of the dashboard pagination

### DIFF
--- a/web/src/components/ArtifactCard.svelte
+++ b/web/src/components/ArtifactCard.svelte
@@ -12,67 +12,65 @@
   const url = computeArtifactUrl(artifact);
 </script>
 
-{#key artifact.id}
-  <section class="p-6 w-full bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700">
-    <div class="flex justify-between items-center mb-4">
-      <div class="flex flex-col justify-center items-start">
-        <a href={url} use:link>
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white break-words">
-            {artifact.name + (artifact.type === 'module' ? ` (${artifact.provider})` : '')}
-          </h2>
-        </a>
-        <h3 class="text-zinc-800 dark:text-zinc-100">
-          @{artifact.namespace}
-        </h3>
-      </div>
-      <div class="flex flex-col justify-center items-center dark:text-white">
-        <Icon 
-          name={artifact.type === 'provider' ? 'cloud' : 'tools'}
-          width="1.5rem"
-          height="1.5rem"
-        />
-        <span class="text-xs text-zinc-800 dark:text-white">
-          {`(${artifact.type})`}
-        </span>
-      </div>
+<section class="p-6 w-full bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700">
+  <div class="flex justify-between items-center mb-4">
+    <div class="flex flex-col justify-center items-start">
+      <a href={url} use:link>
+        <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white break-words">
+          {artifact.name + (artifact.type === 'module' ? ` (${artifact.provider})` : '')}
+        </h2>
+      </a>
+      <h3 class="text-zinc-800 dark:text-zinc-100">
+        @{artifact.namespace}
+      </h3>
     </div>
-    <div class="grid grid-cols-2 gap-4 mb-3 font-normal text-gray-700 dark:text-gray-400 text-sm">
-      <p class="place-self-start">Version:</p>
-      <p class="place-self-end">{artifact.versions[0]}</p>
-      <p class="place-self-start">Updated:</p>
-      <p class="place-self-end">{timeSince(artifact.updatedAt)}</p>
-      <p class="place-self-start">Published:</p>
-      <p class="place-self-end">{timeSince(artifact.createdAt)}</p>
+    <div class="flex flex-col justify-center items-center dark:text-white">
+      <Icon 
+        name={artifact.type === 'provider' ? 'cloud' : 'tools'}
+        width="1.5rem"
+        height="1.5rem"
+      />
+      <span class="text-xs text-zinc-800 dark:text-white">
+        {`(${artifact.type})`}
+      </span>
     </div>
-    <a
-      class="
-        w-full
-        inline-flex
-        justify-center
-        items-center
-        py-2
-        px-3
-        text-sm
-        font-medium
-        text-center
-        text-slate-600
-        dark:text-slate-200
-        bg-teal-400
-        rounded-lg
-        hover:bg-teal-500
-        focus:ring-4
-        focus:outline-none
-        focus:ring-green-300
-        dark:bg-teal-700
-        dark:hover:bg-teal-800
-        dark:focus:ring-green-700
-        {$$props.class}
-      "
-      href={url}
-      use:link
-    >
-      View documentation
-      <Icon name="arrow-forward" class="ml-2 -mr-1" />
-    </a>
-  </section>
-{/key}
+  </div>
+  <div class="grid grid-cols-2 gap-4 mb-3 font-normal text-gray-700 dark:text-gray-400 text-sm">
+    <p class="place-self-start">Version:</p>
+    <p class="place-self-end">{artifact.versions[0]}</p>
+    <p class="place-self-start">Updated:</p>
+    <p class="place-self-end">{timeSince(artifact.updatedAt)}</p>
+    <p class="place-self-start">Published:</p>
+    <p class="place-self-end">{timeSince(artifact.createdAt)}</p>
+  </div>
+  <a
+    class="
+      w-full
+      inline-flex
+      justify-center
+      items-center
+      py-2
+      px-3
+      text-sm
+      font-medium
+      text-center
+      text-slate-600
+      dark:text-slate-200
+      bg-teal-400
+      rounded-lg
+      hover:bg-teal-500
+      focus:ring-4
+      focus:outline-none
+      focus:ring-green-300
+      dark:bg-teal-700
+      dark:hover:bg-teal-800
+      dark:focus:ring-green-700
+      {$$props.class}
+    "
+    href={url}
+    use:link
+  >
+    View documentation
+    <Icon name="arrow-forward" class="ml-2 -mr-1" />
+  </a>
+</section>

--- a/web/src/components/ArtifactsGrid.svelte
+++ b/web/src/components/ArtifactsGrid.svelte
@@ -40,7 +40,7 @@
   const initPages = () => {
     const artifactsCount = filteredArtifacts.length;
 
-    pageCount = artifactsCount > 0 ? Math.floor(artifactsCount / itemsPerPage + 1) : 0;
+    pageCount = artifactsCount > 0 ? Math.floor((artifactsCount - 1) / itemsPerPage + 1) : 0;
     pagesToDisplay = Math.min(pageCount, 5);
   };
 

--- a/web/src/components/ArtifactsGrid.svelte
+++ b/web/src/components/ArtifactsGrid.svelte
@@ -146,7 +146,9 @@
     {#if pageCount > 0}
       <div class="mt-4 flex flex-col justify-center items-center sm:grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {#each filteredArtifacts as artifact}
-          <ArtifactCard artifact={artifact}/>
+          {#key artifact.id}
+            <ArtifactCard artifact={artifact}/>
+          {/key}
         {/each}
       </div>
     {/if}

--- a/web/src/components/ArtifactsGrid.svelte
+++ b/web/src/components/ArtifactsGrid.svelte
@@ -15,6 +15,7 @@
   let itemsPerPage: number = 8;
   let pages: number[] = [];
   let currentPage: number = 0;
+  let artifactsCount: number = 0;
 
   const {
     data: artifacts,
@@ -73,10 +74,14 @@
       $filters.providersEnabled ? ['provider'] : []
     );
 
-    filteredArtifacts = ($artifacts ?? [] as Artifact[]).
-      filter((artifact: Artifact) => currentFilters.includes(artifact.type)).
+    const matchingTypeArtifacts = ($artifacts ?? [] as Artifact[]).
+      filter((artifact: Artifact) => currentFilters.includes(artifact.type));
+
+    artifactsCount = matchingTypeArtifacts.length;
+
+    filteredArtifacts = matchingTypeArtifacts.
       filter((_, id) => (id >= itemsPerPage * currentPage && id < itemsPerPage * (1 + currentPage)));
-  };
+    };
 
   let filtersUnsubscribe: () => void;
 


### PR DESCRIPTION
This PR fixes various dashboard paginations issues:

- URLs on subsequent pages are outdated (pointing to the resources on the first page);
- Empty page (if `artifactsCount = pagesCount * itemsPerPage`);
- Faulty computation of the total number of items;

Fixes #194.