### PR TITLE
fix: Pagination always displays one page

### DIFF
--- a/web/src/components/ArtifactsGrid.svelte
+++ b/web/src/components/ArtifactsGrid.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import { writable, type Writable } from "svelte/store";
   import { useQuery } from "@/lib/hooks";
 
@@ -39,14 +39,13 @@
   };
 
   const initPages = () => {
-    const artifactsCount = filteredArtifacts.length;
-
     pageCount = artifactsCount > 0 ? Math.floor((artifactsCount - 1) / itemsPerPage + 1) : 0;
     pagesToDisplay = Math.min(pageCount, 5);
   };
 
   const buildPages = (pageIndex: number) => {
     currentPage = pageIndex;
+
     updateArtifacts();
 
     let start: number = 0,


### PR DESCRIPTION
This PR fixes the problem described in #194, where the pagination buttons only displays the first page.

It is actually just an unpushed commit from #198. :smiling_face_with_tear: 