### PR TITLE
fix: Crash while rendering provider pages

### DIFF
--- a/web/src/pages/Artifact.svelte
+++ b/web/src/pages/Artifact.svelte
@@ -16,7 +16,7 @@
     type={params.provider ? "module" : "provider"}
     namespace={params.namespace.toLowerCase()}
     name={params.name.toLowerCase()}
-    provider={params.provider.toLowerCase()}
+    provider={params.provider?.toLowerCase()}
     version={params.version}
   />
 {/key}


### PR DESCRIPTION
In #196 I converted all artifact attributes to lower-case without null-checking them first. Because of that (and because the providers don't have a provider field), the artifact page for providers was crashing.