### PR TITLE
feat: Preserve filemode

### DIFF
--- a/pkg/file/inmemory.go
+++ b/pkg/file/inmemory.go
@@ -11,6 +11,7 @@ import (
 // InMemoryFile holds a file in-memory
 type InMemoryFile struct {
 	Name    string
+	FileInfo FileInfo 
 	Content []byte
 }
 
@@ -25,6 +26,15 @@ func Archive(name string, files []*InMemoryFile) (*InMemoryFile, error) {
 		w, err := writer.Create(f.Name)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrArchiveFailure, err)
+		}
+
+		hdr, err := zip.FileInfoHeader(f.FileInfo)
+		if err != nil {
+			return err
+		}
+
+		if _, err := w.CreateHeader(hdr); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrSystemFailure, err)
 		}
 
 		if _, err := w.Write(f.Content); err != nil {
@@ -42,6 +52,7 @@ func Archive(name string, files []*InMemoryFile) (*InMemoryFile, error) {
 
 	return &InMemoryFile{
 		Name:    name,
+		FileInfo: nil,
 		Content: buffer.Bytes(),
 	}, nil
 }

--- a/web/dist/.gitignore
+++ b/web/dist/.gitignore
@@ -1,0 +1,2 @@
+# Ignore all files
+*

--- a/web/dist/.gitignore
+++ b/web/dist/.gitignore
@@ -1,2 +1,0 @@
-# Ignore all files
-*


### PR DESCRIPTION
**Related issue:** https://github.com/terralist/terralist/issues/213.

**Changes introduced**
- When creating an archive, file modes will be preserved

**Implementation**
- `pkg/file/fetch.go` `readFile` function now stats file to gather `fs.FileInfo`
- `pkg/file/fetch.go` `archiveDir` re-use `readFile` to get a file data
- `pkg/file/inmemory.go` `InMemoryFile` extended by `fs.FileInfo` struct
- `pkg/file/inmemory.go` `Archive` use [CreateHeader](https://pkg.go.dev/archive/zip#Writer.CreateHeader) method to archive files with metadata