### PR TITLE
fix: Modules download API should return status 204

### DIFF
--- a/internal/server/controllers/module.go
+++ b/internal/server/controllers/module.go
@@ -90,7 +90,7 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 			}
 
 			ctx.Header("X-Terraform-Get", *location)
-			ctx.JSON(http.StatusOK, gin.H{
+			ctx.JSON(http.StatusNoContent, gin.H{
 				"errors": []string{},
 			})
 		},


### PR DESCRIPTION
Closes #223.

It looks like OpenTofu and Terraform are a bit different in their registry implementation. Terraform accepts both 200 and 204 statuses with the `X-Terraform-Get` header, but OpenTofu accepts only 204 with the same header **OR** 200 status with a JSON body.