### PR TITLE
chore: Upgrade GA actions versions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -57,7 +57,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push development image
-      if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/heads/') }}
+      if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) && !startsWith(github.ref, 'refs/tags/') }}
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,21 +27,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Set the commit hash
       run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -50,15 +50,15 @@ jobs:
       run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push development image
-      if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) }}
-      uses: docker/build-push-action@v4
+      if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/heads/') }}
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
@@ -75,7 +75,7 @@ jobs:
 
     - name: Build and push pre-release image
       if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-pre.') }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
@@ -90,7 +90,7 @@ jobs:
       
     - name: Build and push stable release image
       if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') && (!contains(github.ref, '-pre.')) }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4
 
     - name: Set release version
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -34,7 +34,7 @@ jobs:
         node-version: 18
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 
@@ -53,7 +53,7 @@ jobs:
       run: touch web/dist/.gitkeep
 
     - name: Release stable
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v5
       if: (!contains(github.ref, '-pre.'))
       with:
         version: v0.183.0
@@ -67,7 +67,7 @@ jobs:
       if: contains(github.ref, '-pre.')
       id: changelog
       run: |
-        echo "::set-output name=RELEASE_TAG::${GITHUB_REF#refs/tags/}"
+        echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
           -f tag_name="${GITHUB_REF#refs/tags/}" \
           -f target_commitish=master \
@@ -76,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Release pre-release
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v5
       if: contains(github.ref, '-pre.')
       with:
         version: v0.183.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22'
 


### PR DESCRIPTION
Closes #203.
Closes #202.
Closes #201.
Closes #200.
Closes #199.

This PR upgrades the GA stack to use the recommended runtime `node20`.
