### PR TITLE
feat: Add gh-teams flags to restrict access to some teams only

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -182,7 +182,7 @@ var flags = map[string]cli.Flag{
 		Description: "The GitHub organization to use for user validation.",
 	},
 	GitHubTeamsFlag: &cli.StringFlag{
-		Description: "The GitHub teams in CSV format to use for user validation.",
+		Description: "The GitHub team slugs in CSV format to use for user validation.",
 	},
 	BitBucketClientIDFlag: &cli.StringFlag{
 		Description: "The BitBucket OAuth Application client ID.",

--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -38,6 +38,7 @@ const (
 	GitHubClientIDFlag     = "gh-client-id"
 	GitHubClientSecretFlag = "gh-client-secret"
 	GitHubOrganizationFlag = "gh-organization"
+	GitHubTeamsFlag        = "gh-teams"
 
 	// BitBucket OAuth Flags
 	BitBucketClientIDFlag     = "bb-client-id"
@@ -179,6 +180,9 @@ var flags = map[string]cli.Flag{
 	},
 	GitHubOrganizationFlag: &cli.StringFlag{
 		Description: "The GitHub organization to use for user validation.",
+	},
+	GitHubTeamsFlag: &cli.StringFlag{
+		Description: "The GitHub teams in CSV format to use for user validation.",
 	},
 	BitBucketClientIDFlag: &cli.StringFlag{
 		Description: "The BitBucket OAuth Application client ID.",

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -227,6 +227,7 @@ func (s *Command) run() error {
 			ClientID:     flags[GitHubClientIDFlag].(*cli.StringFlag).Value,
 			ClientSecret: flags[GitHubClientSecretFlag].(*cli.StringFlag).Value,
 			Organization: flags[GitHubOrganizationFlag].(*cli.StringFlag).Value,
+			Teams:        flags[GitHubTeamsFlag].(*cli.StringFlag).Value,
 		})
 	case "bitbucket":
 		provider, err = authFactory.NewProvider(auth.BITBUCKET, &bitbucket.Config{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ The GitHub organization to use for user validation.
 
 ### `gh-teams`
 
-The GitHub teams in CSV format to use for user validation. This requires `gh-organization` to be set.
+The GitHub team slugs in CSV format to use for user validation. This requires `gh-organization` to be set.
 
 | Name | Value |
 | --- | --- |
@@ -761,7 +761,8 @@ gh-client-secret: "${GITHUB_OAUTH_CLIENT_SECRET}"
 gh-organization: "my-org"
 # gh-teams is optional, only users that are part of one of the teams will be able to access the registry
 # gh-organization is required for gh-teams to work
-gh-teams: "teamA,teamB"
+# you must use the slug version of the team
+gh-teams: "team-a,team-b"
 token-signing-secret: "supersecretstring"
 
 database-backend: "sqlite"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,18 @@ The GitHub organization to use for user validation.
 | cli | `--gh-organization` |
 | env | `TERRALIST_GH_ORGANIZATION` |
 
+### `gh-teams`
+
+The GitHub teams in CSV format to use for user validation. This requires `gh-organization` to be set.
+
+| Name | Value |
+| --- | --- |
+| type | string |
+| required | no |
+| default | `n/a` |
+| cli | `--gh-teams` |
+| env | `TERRALIST_GH_TEAMS` |
+
 ### `bb-client-id`
 
 The BitBucket OAuth Application client ID.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -747,7 +747,9 @@ gh-client-secret: "${GITHUB_OAUTH_CLIENT_SECRET}"
 # gh-organization is optional, you can set it to restrict access to the registry
 # only to members of your GitHub organization
 gh-organization: "my-org"
-
+# gh-teams is optional, only users that are part of one of the teams will be able to access the registry
+# gh-organization is required for gh-teams to work
+gh-teams: "teamA,teamB"
 token-signing-secret: "supersecretstring"
 
 database-backend: "sqlite"

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -24,5 +24,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("missing required client secret")
 	}
 
+	if c.Teams != "" && c.Organization == "" {
+		return fmt.Errorf("missing organization when using teams")
+	}
+
 	return nil
 }

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	ClientID     string
 	ClientSecret string
 	Organization string
+	Teams        string
 }
 
 func (c *Config) SetDefaults() {}

--- a/pkg/auth/github/creator.go
+++ b/pkg/auth/github/creator.go
@@ -18,5 +18,6 @@ func (t *Creator) New(config auth.Configurator) (auth.Provider, error) {
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
 		Organization: cfg.Organization,
+		Teams:        cfg.Teams,
 	}, nil
 }

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -81,10 +81,6 @@ func (p *Provider) GetUserDetails(code string, user *auth.User) error {
 	}
 
 	if p.Teams != "" {
-		if p.Organization == "" {
-			return fmt.Errorf("organization is required for teams")
-		}
-
 		if err := p.PerformCheckUserMemberOfTeams(t); err != nil {
 			return err
 		}

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -252,7 +252,7 @@ func (p *Provider) PerformCheckUserMemberOfTeams(t tokenResponse) error {
 
 	for _, team := range userTeams {
 		for _, t := range teams {
-			if team.Name == t {
+			if team.Slug == t {
 				log.Debug().Msgf("user is member of team: %s", t)
 				return nil
 			}

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -3,6 +3,7 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,10 +16,18 @@ type Provider struct {
 	ClientID     string
 	ClientSecret string
 	Organization string
+	Teams        string
 }
 
 type tokenResponse struct {
 	AccessToken string `json:"access_token"`
+}
+
+type Team struct {
+	Name       string
+	Id         int
+	Slug       string
+	Permission string
 }
 
 var (
@@ -67,6 +76,16 @@ func (p *Provider) GetUserDetails(code string, user *auth.User) error {
 
 	if p.Organization != "" {
 		if err := p.PerformCheckUserMemberInOrganization(t); err != nil {
+			return err
+		}
+	}
+
+	if p.Teams != "" {
+		if p.Organization == "" {
+			return fmt.Errorf("organization is required for teams")
+		}
+
+		if err := p.PerformCheckUserMemberOfTeams(t); err != nil {
 			return err
 		}
 	}
@@ -205,4 +224,44 @@ func (p *Provider) PerformCheckUserMemberInOrganization(t tokenResponse) error {
 	}
 
 	return nil
+}
+
+func (p *Provider) PerformCheckUserMemberOfTeams(t tokenResponse) error {
+	teamsEndpoint := fmt.Sprintf("%s/orgs/%s/teams", apiEndpoint, p.Organization)
+
+	req, err := http.NewRequest(http.MethodGet, teamsEndpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", t.AccessToken))
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("unable to list teams of %s", p.Organization)
+	}
+
+	var userTeams []Team
+	if err := json.NewDecoder(res.Body).Decode(&userTeams); err != nil {
+		return fmt.Errorf("unable to parse teams of %s", p.Organization)
+	}
+
+	teams := strings.Split(p.Teams, ",")
+
+	for _, team := range userTeams {
+		for _, t := range teams {
+			if team.Name == t {
+				log.Debug().Msgf("user is member of team: %s", t)
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("user is not a member of any of the teams: %s", p.Teams)
 }


### PR DESCRIPTION
This PR adds another layer of granularity for granting access to the registry. You can now provide a list of github teams in the configuration to filter who has access. This could be useful when your organization is quite big and not everyone should have access to it.

The filter is done on the Name of the team but looks like using the slug would be cleaner.