### PR TITLE
feat(cli): Add support for path-based flags

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -11,6 +11,8 @@ const (
 
 	URLFlag = "url"
 
+	HomeFlag = "home"
+
 	CertFileFlag = "cert-file"
 	KeyFileFlag  = "key-file"
 
@@ -113,6 +115,12 @@ var flags = map[string]cli.Flag{
 	URLFlag: &cli.StringFlag{
 		Description:  "The URL that Terralist is accessible from.",
 		DefaultValue: "http://localhost:5758",
+	},
+
+	HomeFlag: &cli.PathFlag{
+		Description:  "The path to the directory where Terralist can store files.",
+		DefaultValue: "~/.terralist.d",
+		Required:     true,
 	},
 
 	CertFileFlag: &cli.StringFlag{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,19 @@ The URL that Terralist is accessible from.
 | cli | `--url` |
 | env | `TERRALIST_URL` |
 
+### `home`
+
+The path to the directory where Terralist can store files.
+
+| Name | Value |
+| --- | --- |
+| type | string |
+| required | yes |
+| default | `$HOME/.terralist.d` |
+| cli | `--home` |
+| env | `TERRALIST_HOME` |
+
+
 ### `cert-file`
 
 The path to the certificate file (pem format).

--- a/pkg/cli/path_flag.go
+++ b/pkg/cli/path_flag.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// PathFlag holds data for the flags with path values
+type PathFlag struct {
+	Description  string
+	DefaultValue string
+	Hidden       bool
+	Required     bool
+
+	Value string
+
+	isSet bool
+}
+
+func (t *PathFlag) IsHidden() bool {
+	return t.Hidden
+}
+
+func (t *PathFlag) IsSet() bool {
+	return t.isSet
+}
+
+func (t *PathFlag) Set(value any) error {
+	if value == nil {
+		t.Value = t.DefaultValue
+		t.isSet = false
+	} else {
+		v, ok := value.(string)
+		if !ok {
+			s, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("unsupported type %T for path flag", value)
+			}
+
+			if env, ok := environmentLookup(s); ok {
+				s = env
+			}
+
+			v = s
+		}
+
+		if v == "" {
+			if v != t.DefaultValue {
+				t.Value = v
+			} else {
+				t.Value = t.DefaultValue
+			}
+		} else {
+			t.Value = v
+			t.isSet = true
+		}
+	}
+
+	t.Value = sanitizePath(t.Value)
+
+	return nil
+}
+
+func (t *PathFlag) Format() string {
+	return fmt.Sprintf("%s (default %v)", t.Description, t.DefaultValue)
+}
+
+func (t *PathFlag) Validate() error {
+	if t.Required && t.isSet {
+		return fmt.Errorf("required but not set")
+	}
+
+	if !t.Required && t.Value == "" {
+		return nil
+	}
+
+	if !filepath.IsAbs(t.Value) {
+		return fmt.Errorf("not absolute and cannot be resolved to an absolute path")
+	}
+
+	return nil
+}
+
+func sanitizePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+	cwd, _ := os.Getwd()
+
+	if path == "~" {
+		path = dir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(dir, path[2:])
+	} else if path == "." {
+		path = cwd
+	} else if strings.HasPrefix(path, "./") {
+		path = filepath.Join(cwd, path[2:])
+	}
+
+	return path
+}


### PR DESCRIPTION
This PR adds support for PathFlags which are able to resolve a path given as a flag to an absolute path.

In this PR, a `home` flag was also added, which will be later used by Terralist to store various files.