### PR TITLE
feat(storage): Add support for local storage backend

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -85,7 +85,9 @@ const (
 	GcsSignExpireFlag                 = "gcs-sign-expire"
 	GcsServiceAccountCredFilePathFlag = "gcs-service-account-cred-file-path"
 
-	LocalStoreFlag = "local-store"
+	LocalRegistryFlag           = "local-registry"
+	LocalTokenSigningSecretFlag = "local-token-signing-secret"
+	LocalPresignExpireFlag      = "local-presign-expire"
 
 	SessionStoreFlag = "session-store"
 
@@ -231,9 +233,15 @@ var flags = map[string]cli.Flag{
 		Required:    true,
 	},
 
-	LocalStoreFlag: &cli.StringFlag{
-		Description:  "The path to a directory in which Terralist can store files.",
-		DefaultValue: "~/.terralist.d",
+	LocalRegistryFlag: &cli.PathFlag{
+		Description: "The path to a directory in which Terralist can store files.",
+	},
+	LocalTokenSigningSecretFlag: &cli.StringFlag{
+		Description: "The secret to use when generating presigned tokens.",
+	},
+	LocalPresignExpireFlag: &cli.IntFlag{
+		Description:  "The number of minutes after which the presigned URLs should expire.",
+		DefaultValue: 15,
 	},
 
 	ModulesStorageResolverFlag: &cli.StringFlag{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -661,17 +661,42 @@ The server-side encryption algorithm that was used when you store this object in
 | cli | `--s3-server-side-encryption` |
 | env | `TERRALIST_S3_SERVER_SIDE_ENCRYPTION` |
 
-### `local-store`
+### `local-registry`
 
-The path to a directory in which Terralist can store files.
+The path to a directory in which Terralist can store registry files (modules and providers). If not given, it will be computed from `home` as `{home}/registry`. By default, it will be set to `~/.terralist.d/registry`.
 
 | Name | Value |
 | --- | --- |
 | type | string |
 | required | no |
-| default | `~/.terralist.d` |
-| cli | `--local-store` |
-| env | `TERRALIST_LOCAL_STORE` |
+| default | `~/.terralist.d/registry` |
+| cli | `--local-registry` |
+| env | `TERRALIST_LOCAL_REGISTRY` |
+
+### `local-token-signing-secret`
+
+The secret to use when generating presigned tokens.
+
+| Name | Value |
+| --- | --- |
+| type | string |
+| required | no |
+| default | `n/a` |
+| cli | `--local-token-signing-secret` |
+| env | `TERRALIST_LOCAL_TOKEN_SIGNING_SECRET` |
+
+
+### `local-presign-expire`
+
+The number of minutes after which the presigned URLs should expire.
+
+| Name | Value |
+| --- | --- |
+| type | int |
+| required | no |
+| default | `15` |
+| cli | `--local-presign-expire` |
+| env | `TERRALIST_LOCAL_PRESIGN_EXPIRE` |
 
 ### `azure-account-name`
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -1,14 +1,15 @@
 package server
 
 type UserConfig struct {
-	LogLevel               string `mapstructure:"log-level"`
-	Port                   int    `mapstructure:"port"`
-	URL                    string `mapstructure:"url"`
-	CertFile               string `mapstructure:"cert-file"`
-	KeyFile                string `mapstructure:"key-file"`
-	TokenSigningSecret     string `mapstructure:"token-signing-secret"`
-	OauthProvider          string `mapstructure:"oauth-provider"`
-	CustomCompanyName      string `mapstructure:"custom-company-name"`
-	ModulesAnonymousRead   bool   `mapstructure:"modules-anonymous-read"`
-	ProvidersAnonymousRead bool   `mapstructure:"providers-anonymous-read"`
+	LogLevel                string `mapstructure:"log-level"`
+	Port                    int    `mapstructure:"port"`
+	URL                     string `mapstructure:"url"`
+	CertFile                string `mapstructure:"cert-file"`
+	KeyFile                 string `mapstructure:"key-file"`
+	TokenSigningSecret      string `mapstructure:"token-signing-secret"`
+	OauthProvider           string `mapstructure:"oauth-provider"`
+	CustomCompanyName       string `mapstructure:"custom-company-name"`
+	ModulesAnonymousRead    bool   `mapstructure:"modules-anonymous-read"`
+	ProvidersAnonymousRead  bool   `mapstructure:"providers-anonymous-read"`
+	LocalTokenSigningSecret string `mapstructure:"local-token-signing-secret"`
 }

--- a/internal/server/controllers/file.go
+++ b/internal/server/controllers/file.go
@@ -1,0 +1,112 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"terralist/pkg/api"
+	"terralist/pkg/auth/jwt"
+	"terralist/pkg/storage"
+	"terralist/pkg/storage/local"
+
+	"github.com/gin-gonic/gin"
+)
+
+// FileServer registers the routes that handles the files
+type FileServer interface {
+	api.RestController
+}
+
+// DefaultFileServer is a concrete implementation of FileServer
+type DefaultFileServer struct {
+	ModulesResolver   storage.Resolver
+	ProvidersResolver storage.Resolver
+
+	JWT jwt.JWT
+}
+
+func (c *DefaultFileServer) Paths() []string {
+	return []string{"/files"}
+}
+
+func (c *DefaultFileServer) Subscribe(apis ...*gin.RouterGroup) {
+	api := apis[0]
+
+	localModulesResolver, ok := c.ModulesResolver.(*local.Resolver)
+	if !ok {
+		localModulesResolver = nil
+	}
+
+	localProvidersResolver, ok := c.ProvidersResolver.(*local.Resolver)
+	if !ok {
+		localProvidersResolver = nil
+	}
+
+	api.GET("/modules/*filepath", func(ctx *gin.Context) {
+		if localModulesResolver == nil {
+			ctx.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		fileKey := filepath.Join("modules", ctx.Param("filepath"))
+		token := ctx.Query("token")
+
+		if _, err := c.JWT.Extract(token); err != nil {
+			ctx.AbortWithError(http.StatusUnauthorized, err)
+			return
+		}
+
+		file, err := localModulesResolver.GetObject(fileKey)
+		if err != nil {
+			if !errors.Is(err, local.ErrFileNotFound) {
+				ctx.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
+
+			ctx.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		ctx.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", file.Name))
+		ctx.Header("Content-Type", "application/octet-stream")
+
+		ctx.Writer.Write(file.Content)
+
+		ctx.Status(http.StatusOK)
+	})
+
+	api.GET("/providers/*filepath", func(ctx *gin.Context) {
+		if localProvidersResolver == nil {
+			ctx.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		fileKey := filepath.Join("modules", ctx.Param("filepath"))
+		token := ctx.Query("token")
+
+		if _, err := c.JWT.Extract(token); err != nil {
+			ctx.AbortWithError(http.StatusUnauthorized, err)
+			return
+		}
+
+		file, err := localProvidersResolver.GetObject(fileKey)
+		if err != nil {
+			if !errors.Is(err, local.ErrFileNotFound) {
+				ctx.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
+
+			ctx.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		ctx.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", file.Name))
+		ctx.Header("Content-Type", "application/octet-stream")
+
+		ctx.Writer.Write(file.Content)
+
+		ctx.Status(http.StatusOK)
+	})
+}

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
 	"terralist/internal/server/services"
 	"terralist/pkg/auth"
 	"terralist/pkg/auth/jwt"
@@ -46,9 +47,15 @@ func (a *Authorization) hasAuthorizationHeader(c *gin.Context) (*auth.User, erro
 	var user *auth.User
 
 	if !strings.HasPrefix(bearerToken, "x-api-key:") {
-		user, err = a.JWT.Extract(bearerToken)
+		data, err := a.JWT.Extract(bearerToken)
 		if err != nil {
 			return nil, fmt.Errorf("Authorization: %w", ErrInvalidValue)
+		}
+
+		if u, ok := data.(auth.User); !ok {
+			return nil, fmt.Errorf("Authorization: %w", ErrInvalidValue)
+		} else {
+			user = &u
 		}
 	} else {
 		var apiKey string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -226,6 +226,20 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		ClearSessionRoute:     apiV1Group.Prefix() + loginController.ClearSessionRoute(),
 	})
 
+	localJWTManager, err := jwt.New(userConfig.LocalTokenSigningSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local JWT manager: %v", err)
+	}
+
+	filesController := &controllers.DefaultFileServer{
+		ModulesResolver:   config.ModulesResolver,
+		ProvidersResolver: config.ProvidersResolver,
+
+		JWT: localJWTManager,
+	}
+
+	apiV1Group.Register(filesController)
+
 	return &Server{
 		Port:     userConfig.Port,
 		CertFile: userConfig.CertFile,

--- a/pkg/auth/jwt/jwt_test.go
+++ b/pkg/auth/jwt/jwt_test.go
@@ -50,13 +50,18 @@ func TestJWT_User(t *testing.T) {
 		t.Fatalf("build returned with error: %v", err)
 	}
 
-	u, err := j.Extract(token)
+	data, err := j.Extract(token)
 	if err != nil {
 		t.Fatalf("extract returned with error: %v", err)
 	}
 
-	if *u != user {
-		t.Fatalf("user mismatch, expected = %v, got = %v", user, *u)
+	u, ok := data.(auth.User)
+	if !ok {
+		t.Fatalf("token data was not of type auth.User, but %T", data)
+	}
+
+	if u != user {
+		t.Fatalf("user mismatch, expected = %v, got = %v", user, u)
 	}
 }
 

--- a/pkg/auth/user.go
+++ b/pkg/auth/user.go
@@ -1,12 +1,23 @@
 package auth
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+	"encoding/json"
+)
 
 // User holds the user authorized user data
 type User struct {
 	Name        string `json:"name"`
 	Email       string `json:"email"`
 	AuthorityID string `json:"authority_id"`
+}
+
+func (u User) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u)
+}
+
+func (u User) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &u)
 }
 
 func init() {

--- a/pkg/storage/local/config.go
+++ b/pkg/storage/local/config.go
@@ -1,7 +1,11 @@
 package local
 
 import (
-	"path"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -11,13 +15,61 @@ const (
 // Config implements storage.Configurator interface and
 // handles the configuration parameters of the local resolver
 type Config struct {
-	HomeDirectory string
+	HomeDirectory     string
+	RegistryDirectory string
+	BaseURL           string
+	FilesEndpoint     string
+
+	TokenSigningSecret string
+	LinkExpire         int
 }
 
 func (c *Config) SetDefaults() {
-	c.HomeDirectory = path.Join(c.HomeDirectory, registryDirName)
+	if c.RegistryDirectory == "" {
+		c.RegistryDirectory = filepath.Join(sanitizePath(c.HomeDirectory), registryDirName)
+	} else {
+		c.RegistryDirectory = sanitizePath(c.RegistryDirectory)
+	}
 }
 
 func (c *Config) Validate() error {
+	if c.BaseURL == "" {
+		return fmt.Errorf("local resolver needs to know the base URL")
+	}
+
+	if c.FilesEndpoint == "" {
+		return fmt.Errorf("local resolver needs to know the files endpoint")
+	}
+
+	if c.TokenSigningSecret == "" {
+		return fmt.Errorf("a secret for signing tokens is required")
+	}
+
+	if c.LinkExpire <= 0 {
+		return fmt.Errorf("the expire time for links must be positive > 0")
+	}
+
 	return nil
+}
+
+func sanitizePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+	cwd, _ := os.Getwd()
+
+	if path == "~" {
+		path = dir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(dir, path[2:])
+	} else if path == "." {
+		path = cwd
+	} else if strings.HasPrefix(path, "./") {
+		path = filepath.Join(cwd, path[2:])
+	}
+
+	return path
 }

--- a/pkg/storage/local/resolver.go
+++ b/pkg/storage/local/resolver.go
@@ -1,27 +1,125 @@
 package local
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path"
 
+	"terralist/pkg/auth/jwt"
+	"terralist/pkg/file"
 	"terralist/pkg/storage"
 )
 
 // The local resolver will download files to a given path on the disk
 // and will generate a public URL from which they can be downloaded
 
+var (
+	ErrFileNotFound = errors.New("file not found")
+)
+
 // Resolver is the concrete implementation of storage.Resolver
 type Resolver struct {
 	RegistryDir string
+	LinkExpire  int
+	URLFormat   string
+
+	JWT jwt.JWT
 }
 
-func (r *Resolver) Store(_ *storage.StoreInput) (string, error) {
-	return "", fmt.Errorf("not yet implemented")
+func (r *Resolver) Store(in *storage.StoreInput) (string, error) {
+	fileKey := path.Join(in.KeyPrefix, in.FileName)
+	filePath := path.Join(r.RegistryDir, fileKey)
+
+	_, err := os.Stat(filePath)
+
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	// If the file already exists, remove it first so it can be overwritten
+	if err == nil {
+		os.Remove(filePath)
+	}
+
+	if err := os.WriteFile(filePath, in.Content, 0700); err != nil {
+		return "", fmt.Errorf("could not store file: %w", err)
+	}
+
+	return fileKey, nil
 }
 
-func (r *Resolver) Find(_ string) (string, error) {
-	return "", fmt.Errorf("not yet implemented")
+// ObjectExists checks if a given path exists on the disk
+func (r *Resolver) ObjectExists(key string) (string, error) {
+	filePath := path.Join(r.RegistryDir, key)
+
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrFileNotFound
+		}
+
+		return "", err
+	}
+
+	return filePath, nil
 }
 
-func (r *Resolver) Purge(_ string) error {
-	return nil
+// GetObject reads a file from the disk and returns it as an InMemoryFile abstraction
+func (r *Resolver) GetObject(key string) (*file.InMemoryFile, error) {
+	filePath, err := r.ObjectExists(key)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat file: %w", err)
+	}
+
+	buffer := new(bytes.Buffer)
+	if _, err := io.Copy(buffer, f); err != nil {
+		return nil, err
+	}
+
+	return &file.InMemoryFile{
+		Name:     fi.Name(),
+		FileInfo: fi,
+		Content:  buffer.Bytes(),
+	}, nil
+}
+
+func (r *Resolver) Find(key string) (string, error) {
+	_, err := r.ObjectExists(key)
+	if err != nil {
+		return "", fmt.Errorf("could not generate URL for %v: %w", key, err)
+	}
+
+	token, err := r.JWT.Build(nil, r.LinkExpire)
+	if err != nil {
+		return "", fmt.Errorf("could not generate a temporarily token: %w", err)
+	}
+
+	return fmt.Sprintf(r.URLFormat, key, token), nil
+}
+
+func (r *Resolver) Purge(key string) error {
+	filePath, err := r.ObjectExists(key)
+	if err != nil {
+		if !errors.Is(err, ErrFileNotFound) {
+			return err
+		}
+
+		return nil
+	}
+
+	return os.Remove(filePath)
 }


### PR DESCRIPTION
This PR adds support for `local` storage backend. This backend allows Terralist to store uploaded modules and providers on its local disk.

This is currently work in progress, as I couldn't manage to make the JWT tokens work properly. Before merging this, a full authentication testing should be performed, as the JWT implementation is reworked in this PR.