### PR TITLE
feat(api): Upload modules with content

### DIFF
--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -180,6 +180,7 @@ func (s *Command) run() error {
 		CustomCompanyName:      flags[CustomCompanyNameFlag].(*cli.StringFlag).Value,
 		ModulesAnonymousRead:   flags[ModulesAnonymousReadFlag].(*cli.BoolFlag).Value,
 		ProvidersAnonymousRead: flags[ProvidersAnonymousReadFlag].(*cli.BoolFlag).Value,
+		Home:                   flags[HomeFlag].(*cli.PathFlag).Value,
 	}
 
 	if s.RunningMode == "debug" {

--- a/docs/dev-guide/api-reference.md
+++ b/docs/dev-guide/api-reference.md
@@ -234,11 +234,13 @@ curl -L -X POST \
 
 !!! note "There is no need for you to specify the namespace, as Terralist will resolve it based on your API key."
 
-### Example Response
-
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -251,12 +253,12 @@ curl -L -X POST \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```
@@ -283,7 +285,11 @@ curl -L -X DELETE \
 
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -296,12 +302,12 @@ curl -L -X DELETE \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```
@@ -328,7 +334,11 @@ curl -L -X DELETE \
 
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -341,12 +351,12 @@ curl -L -X DELETE \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```
@@ -482,7 +492,11 @@ curl -L -X POST \
 
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -495,15 +509,66 @@ curl -L -X POST \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```
+
+## Upload a module version (with local files)
+
+```
+POST /v1/api/modules/:name/:provider/:version/upload-files
+```
+
+Upload a new module version (with local files).
+
+### Example Request
+
+``` shell
+curl -L -X POST \
+  -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
+  -F "module=@/path/to/your-module.zip"
+  http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload-files
+```
+
+!!! note "There is no need for you to specify the namespace, as Terralist will resolve it based on your API key."
+
+### Example Response
+
+=== "Status 200"
+
+    ``` json
+    {
+      "errors": []
+    }
+    ```
+
+=== "Status 401"
+
+    ``` json
+    {
+      "errors": [
+        "Authorization: missing",
+        "X-API-Key: missing"
+      ]
+    }
+    ```
+
+=== "Status 4xx/5xx"
+
+    ``` json
+    {
+      "errors": [
+        "...",
+      ]
+    }
+    ```
+
 ## Remove a module
 
 ```
@@ -522,11 +587,13 @@ curl -L -X DELETE \
 
 !!! note "There is no need for you to specify the namespace, as Terralist will resolve it based on your API key."
 
-### Example Response
-
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -539,12 +606,12 @@ curl -L -X DELETE \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```
@@ -571,7 +638,11 @@ curl -L -X DELETE \
 
 === "Status 200"
 
-    TODO
+    ``` json
+    {
+      "errors": []
+    }
+    ```
 
 === "Status 401"
 
@@ -584,12 +655,12 @@ curl -L -X DELETE \
     }
     ```
 
-=== "Status 404"
+=== "Status 4xx/5xx"
 
     ``` json
     {
       "errors": [
-        "not found"
+        "...",
       ]
     }
     ```

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -4,6 +4,7 @@ type UserConfig struct {
 	LogLevel               string `mapstructure:"log-level"`
 	Port                   int    `mapstructure:"port"`
 	URL                    string `mapstructure:"url"`
+	Home                   string `mapstructure:"home"`
 	CertFile               string `mapstructure:"cert-file"`
 	KeyFile                string `mapstructure:"key-file"`
 	TokenSigningSecret     string `mapstructure:"token-signing-secret"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -159,6 +159,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		ModuleService: moduleService,
 		Authorization: authorization,
 		AnonymousRead: userConfig.ModulesAnonymousRead,
+
+		HomeDir: userConfig.Home,
 	}
 
 	apiV1Group.Register(moduleController)


### PR DESCRIPTION
Closes #33.

This PR adds a new endpoint that allows users to upload the module files directly from the local disk, instead of asking Terralist to download them from somewhere else.

To avoid creating a breaking change, it will be a different endpoint, for now, but most probably it will be merged with the original one before v1 release.