### PR TITLE
feat(api): Accept custom HTTP headers

### DIFF
--- a/docs/dev-guide/api-reference.md
+++ b/docs/dev-guide/api-reference.md
@@ -504,19 +504,38 @@ If the URL from which the module files should be downloaded is of types `http` o
 
 ### Example Request
 
-``` shell
-curl -L -X POST \
-  -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
-  -d '{
-    "download_url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{ASSET-ID}",
-    "headers": {
-        "Accept": "application/octet-stream",
-        "Authorization:": "Bearer {TOKEN}",
-        "X-GitHub-Api-Version": "2022-11-28"
-    }
-  }' \
-  http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload
-```
+=== "GitHub API"
+
+    ``` shell
+    curl -L -X POST \
+      -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
+      -d '{
+        "download_url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{ASSET-ID}",
+        "headers": {
+            "Accept": "application/octet-stream",
+            "Authorization:": "Bearer {TOKEN}",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+      }' \
+      http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload
+    ```
+
+=== "GitHub HTTP"
+
+    ``` shell
+    curl -L -X POST \
+      -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
+      -d '{
+        "download_url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{RELEASE-TAG-NAME}.zip",
+        "headers": {
+            "Accept": "application/octet-stream",
+            "Authorization:": "Basic {YOUR-GITHUB-BASE64ENC-USERNAME-TOKEN}"
+        }
+      }' \
+      http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload
+    ```
+
+    !!! note "To obtain the basic auth token you can base64-encode the following string: `{your-github-username}:{your-github-pat-with-read-access-to-the-repository}` "
 
 !!! note "There is no need for you to specify the namespace, as Terralist will resolve it based on your API key."
 

--- a/docs/dev-guide/api-reference.md
+++ b/docs/dev-guide/api-reference.md
@@ -224,11 +224,33 @@ POST /v1/api/providers/:name/:version/upload
 
 Upload a new provider version.
 
+If the URLs from which the provider files should be downloaded are of types `http` or `https`, a dictionary of headers can be additionally passed, depending on your needs. If those headers are passed-in for other URL types, they will be ignored.
+
 ### Example Request
 
 ``` shell
 curl -L -X POST \
   -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
+  -d '{
+    "protocols": ["5.0"],
+    "headers": {
+      "Accept": "application/octet-stream",
+      "Authorization:": "Bearer {TOKEN}",
+      "X-GitHub-Api-Version": "2022-11-28"
+    },
+    "shasums": {
+      "url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{SHA256SUMS-ASSET-ID}",
+      "signature_url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{SHA256SUMS-SIG-ASSET-ID}",
+    },
+    "platforms": [
+      {
+        "os": "linux",
+        "arch": "amd64",
+        "download_url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{PROVIDER-LINUX-AMD64-ASSET-ID}",
+        "shasum": "{SHASUM}"
+      }
+    ]
+  }' \
   http://localhost:5758/v1/api/providers/NAME/VERSION/upload
 ```
 
@@ -478,11 +500,21 @@ POST /v1/api/modules/:name/:provider/:version/upload
 
 Upload a new module version.
 
+If the URL from which the module files should be downloaded is of types `http` or `https`, a dictionary of headers can be additionally passed, depending on your needs. If those headers are passed-in for other URL types, they will be ignored.
+
 ### Example Request
 
 ``` shell
 curl -L -X POST \
   -H "Authorization: Bearer x-api-key:<YOUR-TOKEN>" \
+  -d '{
+    "download_url": "https://api.github.com/repos/{OWNER}/{REPO}/releases/assets/{ASSET-ID}",
+    "headers": {
+        "Accept": "application/octet-stream",
+        "Authorization:": "Bearer {TOKEN}",
+        "X-GitHub-Api-Version": "2022-11-28"
+    }
+  }' \
   http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload
 ```
 

--- a/docs/dev-guide/api-reference.md
+++ b/docs/dev-guide/api-reference.md
@@ -535,7 +535,7 @@ If the URL from which the module files should be downloaded is of types `http` o
       http://localhost:5758/v1/api/modules/NAME/PROVIDER/VERSION/upload
     ```
 
-    !!! note "To obtain the basic auth token you can base64-encode the following string: `{your-github-username}:{your-github-pat-with-read-access-to-the-repository}` "
+    !!! note "To obtain the basic auth token you can base64-encode the following string: `{your-github-username}:{your-github-pat-with-read-access-to-the-repository}`."
 
 !!! note "There is no need for you to specify the namespace, as Terralist will resolve it based on your API key."
 

--- a/e2e/suites/modules.v1.yaml
+++ b/e2e/suites/modules.v1.yaml
@@ -113,8 +113,10 @@ testcases:
   - type: http
     method: POST
     url: {{.url}}/v1/api/modules/{{.goodName}}/{{.provider}}/{{.goodVersion}}/upload
-    body: |
-      {"download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip"}
+    body: >-
+      {
+        "download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip"
+      }
     headers:
       Authorization: Bearer x-api-key:{{.modulesApiKey}}
     timeout: 60
@@ -131,8 +133,14 @@ testcases:
     url: {{.url}}/v1/api/modules/{{.goodName}}/{{.provider}}/{{.badVersion}}/upload
     headers:
       Authorization: Bearer x-api-key:{{.modulesApiKey}}
-    body: |
-      {"download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip"}
+    body: >-
+      {
+        "download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip",
+        "headers": {
+          "Accept": "*/*",
+          "User-Agent": "Terralist/1.0 e2erun"
+        }
+      }
     timeout: 60
     assertions:
     - result.statuscode ShouldEqual 200
@@ -162,8 +170,10 @@ testcases:
     url: {{.url}}/v1/api/modules/{{.badName}}/{{.provider}}/{{.badVersion}}/upload
     headers:
       Authorization: Bearer x-api-key:{{.modulesApiKey}}
-    body: |
-      {"download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip"}
+    body: >-
+      {
+        "download_url": "https://github.com/terraform-aws-modules/terraform-aws-vpc/archive/refs/tags/v5.7.2.zip"
+      }
     timeout: 60
     assertions:
     - result.statuscode ShouldEqual 200

--- a/e2e/suites/providers.v1.yaml
+++ b/e2e/suites/providers.v1.yaml
@@ -161,6 +161,10 @@ testcases:
     body: >-
       {
         "protocols": ["5.0"],
+        "headers": {
+          "Accept": "*/*",
+          "User-Agent": "Terralist/1.0 e2erun"
+        },
         "shasums": {
           "url": "https://releases.hashicorp.com/terraform-provider-aws/5.47.0/terraform-provider-aws_5.47.0_SHA256SUMS",
           "signature_url": "https://releases.hashicorp.com/terraform-provider-aws/5.47.0/terraform-provider-aws_5.47.0_SHA256SUMS.72D7468F.sig"

--- a/internal/server/controllers/module.go
+++ b/internal/server/controllers/module.go
@@ -137,7 +137,9 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 				return
 			}
 
-			if err := c.ModuleService.Upload(&dto, body.DownloadUrl); err != nil {
+			header := file.CreateHeader(body.Headers)
+
+			if err := c.ModuleService.Upload(&dto, body.DownloadUrl, header); err != nil {
 				ctx.JSON(http.StatusConflict, gin.H{
 					"errors": []string{err.Error()},
 				})
@@ -217,7 +219,7 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 
 			// Pass-in local-file URI for go-getter
 			uri := fmt.Sprintf("file://%v", onDiskFile.Path())
-			if err := c.ModuleService.Upload(&dto, uri); err != nil {
+			if err := c.ModuleService.Upload(&dto, uri, nil); err != nil {
 				ctx.JSON(http.StatusConflict, gin.H{
 					"errors": []string{err.Error()},
 				})

--- a/internal/server/models/module/module.go
+++ b/internal/server/models/module/module.go
@@ -85,7 +85,8 @@ type CreateDTO struct {
 }
 
 type CreateFromURLDTO struct {
-	DownloadUrl string `json:"download_url"`
+	DownloadUrl string            `json:"download_url"`
+	Headers     map[string]string `json:"headers,omitempty"`
 }
 
 func (d CreateDTO) ToModule() Module {

--- a/internal/server/models/provider/provider.go
+++ b/internal/server/models/provider/provider.go
@@ -65,6 +65,7 @@ type CreateProviderDTO struct {
 	ShaSums     CreateProviderShaSumsDTO `json:"shasums"`
 	Protocols   []string                 `json:"protocols"`
 	Platforms   []CreatePlatformDTO      `json:"platforms"`
+	Headers     map[string]string        `json:"headers,omitempty"`
 }
 
 func (d CreateProviderDTO) ToProvider() Provider {

--- a/internal/server/services/module.go
+++ b/internal/server/services/module.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"net/http"
 
 	"terralist/internal/server/models/module"
 	"terralist/internal/server/repositories"
@@ -24,7 +25,7 @@ type ModuleService interface {
 
 	// Upload loads a new module version to the system
 	// If the module does not exist, it will be created
-	Upload(dto *module.CreateDTO, url string) error
+	Upload(dto *module.CreateDTO, url string, header http.Header) error
 
 	// Delete removes a module with all its data from the system
 	Delete(authorityID uuid.UUID, name string, provider string) error
@@ -71,7 +72,7 @@ func (s *DefaultModuleService) GetVersion(namespace, name, provider, version str
 	return location, nil
 }
 
-func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string) error {
+func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header http.Header) error {
 	// Validate version
 	if semVer := version.Version(d.Version); !semVer.Valid() {
 		return fmt.Errorf("version should respect the semantic versioning standard (semver.org)")
@@ -96,7 +97,7 @@ func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string) error {
 
 	if s.Resolver != nil {
 		// Download module files
-		archive, err := s.Fetcher.Fetch(d.Version, url)
+		archive, err := s.Fetcher.Fetch(d.Version, url, header)
 		if err != nil {
 			return err
 		}

--- a/internal/server/services/module_test.go
+++ b/internal/server/services/module_test.go
@@ -277,7 +277,7 @@ func TestUploadModule(t *testing.T) {
 
 								Convey("If the module files cannot be downloaded", func() {
 									mockFetcher.
-										On("Fetch", dto.Version, url).
+										On("Fetch", dto.Version, url, mock.AnythingOfType("http.Header")).
 										Return(nil, errors.New(""))
 
 									Convey("When the service is queried", func() {
@@ -291,7 +291,7 @@ func TestUploadModule(t *testing.T) {
 
 								Convey("If the module files can be downloaded", func() {
 									mockFetcher.
-										On("Fetch", dto.Version, url).
+										On("Fetch", dto.Version, url, mock.AnythingOfType("http.Header")).
 										Return(file.NewEmptyFile("test.txt"), nil)
 
 									Convey("If the resolver fails to store the module files", func() {

--- a/internal/server/services/module_test.go
+++ b/internal/server/services/module_test.go
@@ -180,7 +180,7 @@ func TestUploadModule(t *testing.T) {
 				dto.Version = "100%-not-sem-ver-valid"
 
 				Convey("When the service is queried", func() {
-					err := moduleService.Upload(&dto, url)
+					err := moduleService.Upload(&dto, url, nil)
 
 					Convey("An error should be returned", func() {
 						So(err, ShouldNotBeNil)
@@ -197,7 +197,7 @@ func TestUploadModule(t *testing.T) {
 						Return(nil, errors.New(""))
 
 					Convey("When the service is queried", func() {
-						err := moduleService.Upload(&dto, url)
+						err := moduleService.Upload(&dto, url, nil)
 
 						Convey("An error should be returned", func() {
 							So(err, ShouldNotBeNil)
@@ -222,7 +222,7 @@ func TestUploadModule(t *testing.T) {
 							}, nil)
 
 						Convey("When the service is queried", func() {
-							err := moduleService.Upload(&dto, url)
+							err := moduleService.Upload(&dto, url, nil)
 
 							Convey("An error should be returned", func() {
 								So(err, ShouldNotBeNil)
@@ -264,7 +264,7 @@ func TestUploadModule(t *testing.T) {
 									Return(&module.Module{}, nil)
 
 								Convey("When the service is queried", func() {
-									err := moduleService.Upload(&dto, url)
+									err := moduleService.Upload(&dto, url, nil)
 
 									Convey("No error should be returned", func() {
 										So(err, ShouldBeNil)
@@ -281,7 +281,7 @@ func TestUploadModule(t *testing.T) {
 										Return(nil, errors.New(""))
 
 									Convey("When the service is queried", func() {
-										err := moduleService.Upload(&dto, url)
+										err := moduleService.Upload(&dto, url, nil)
 
 										Convey("An error should be returned", func() {
 											So(err, ShouldNotBeNil)
@@ -300,7 +300,7 @@ func TestUploadModule(t *testing.T) {
 											Return("", errors.New(""))
 
 										Convey("When the service is queried", func() {
-											err := moduleService.Upload(&dto, url)
+											err := moduleService.Upload(&dto, url, nil)
 
 											Convey("An error should be returned", func() {
 												So(err, ShouldNotBeNil)
@@ -320,7 +320,7 @@ func TestUploadModule(t *testing.T) {
 											Return(&module.Module{}, nil)
 
 										Convey("When the service is queried", func() {
-											err := moduleService.Upload(&dto, url)
+											err := moduleService.Upload(&dto, url, nil)
 
 											Convey("No error should be returned", func() {
 												So(err, ShouldBeNil)

--- a/internal/server/services/provider.go
+++ b/internal/server/services/provider.go
@@ -242,13 +242,15 @@ func (s *DefaultProviderService) resolveLocations(d *provider.DownloadPlatformDT
 func (s *DefaultProviderService) downloadFiles(d *provider.CreateProviderDTO) (map[string]file.File, error) {
 	prefix := fmt.Sprintf("terraform-provider-%s_%s", d.Name, d.Version)
 
+	headers := file.CreateHeader(d.Headers)
+
 	// Download provider files
-	shaSums, err := s.Fetcher.FetchFile(fmt.Sprintf("%s_SHA256SUMS", prefix), d.ShaSums.URL)
+	shaSums, err := s.Fetcher.FetchFile(fmt.Sprintf("%s_SHA256SUMS", prefix), d.ShaSums.URL, headers)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch shaSums file: %v", err)
 	}
 
-	shaSumsSig, err := s.Fetcher.FetchFile(fmt.Sprintf("%s_SHA256SUMS.sig", prefix), d.ShaSums.SignatureURL)
+	shaSumsSig, err := s.Fetcher.FetchFile(fmt.Sprintf("%s_SHA256SUMS.sig", prefix), d.ShaSums.SignatureURL, headers)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch shaSums sig file: %v", err)
 	}
@@ -262,11 +264,7 @@ func (s *DefaultProviderService) downloadFiles(d *provider.CreateProviderDTO) (m
 		p := platform.ToPlatform()
 		osArch := p.String()
 
-		binary, err := s.Fetcher.FetchFileChecksum(
-			fmt.Sprintf("%s_%s.zip", prefix, osArch),
-			p.Location,
-			p.ShaSum,
-		)
+		binary, err := s.Fetcher.FetchFileChecksum(fmt.Sprintf("%s_%s.zip", prefix, osArch), p.Location, p.ShaSum, headers)
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch %s file: %v", osArch, err)
 		}

--- a/internal/server/services/provider_test.go
+++ b/internal/server/services/provider_test.go
@@ -362,7 +362,12 @@ func TestUploadProvider(t *testing.T) {
 
 								Convey("If the provider files cannot be downloaded", func() {
 									mockFetcher.
-										On("FetchFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+										On(
+											"FetchFile",
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("http.Header"),
+										).
 										Return(nil, errors.New(""))
 
 									Convey("When the service is queried", func() {
@@ -376,11 +381,22 @@ func TestUploadProvider(t *testing.T) {
 
 								Convey("If the provider files can be downloaded", func() {
 									mockFetcher.
-										On("FetchFile", mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+										On(
+											"FetchFile",
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("http.Header"),
+										).
 										Return(file.NewEmptyFile("test.txt"), nil)
 
 									mockFetcher.
-										On("FetchFileChecksum", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+										On(
+											"FetchFileChecksum",
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("string"),
+											mock.AnythingOfType("http.Header"),
+										).
 										Return(file.NewEmptyFile("test-with-checksum.txt"), nil)
 
 									Convey("If the resolver cannot store the provider files", func() {

--- a/pkg/file/fetcher.go
+++ b/pkg/file/fetcher.go
@@ -1,27 +1,29 @@
 package file
 
+import "net/http"
+
 type Fetcher interface {
 	// Fetch downloads a file or a directory from a given URL
 	// and returns it
 	// If the file is a directory, it will be archived
 	// If the file is an archive, it will be decompressed, and
 	// then compressed back to zip
-	Fetch(name string, url string) (File, error)
+	Fetch(name string, url string, header http.Header) (File, error)
 
 	// FetchFile downloads a file from a given URL and returns it
-	FetchFile(name string, url string) (File, error)
+	FetchFile(name string, url string, header http.Header) (File, error)
 
 	// FetchFileChecksum downloads a file from a given URL while
 	// checking a given checksum and returns it
-	FetchFileChecksum(name string, url string, checksum string) (File, error)
+	FetchFileChecksum(name string, url string, checksum string, header http.Header) (File, error)
 
 	// FetchDir downloads all files from a given URL and returns
 	// them as an archive
-	FetchDir(name string, url string) (File, error)
+	FetchDir(name string, url string, header http.Header) (File, error)
 
 	// FetchDirChecksum downloads all files from a given URL while
 	// checking a given checksum and returns them as an archive
-	FetchDirChecksum(name string, url string, checksum string) (File, error)
+	FetchDirChecksum(name string, url string, checksum string, header http.Header) (File, error)
 }
 
 const (
@@ -36,22 +38,36 @@ func NewFetcher() Fetcher {
 	return &defaultFetcher{}
 }
 
-func (*defaultFetcher) Fetch(name string, url string) (File, error) {
-	return fetch(name, url, "", any)
+func (*defaultFetcher) Fetch(name string, url string, header http.Header) (File, error) {
+	return fetch(name, url, "", any, header)
 }
 
-func (*defaultFetcher) FetchFile(name string, url string) (File, error) {
-	return fetch(name, url, "", file)
+func (*defaultFetcher) FetchFile(name string, url string, header http.Header) (File, error) {
+	return fetch(name, url, "", file, header)
 }
 
-func (*defaultFetcher) FetchFileChecksum(name string, url string, checksum string) (File, error) {
-	return fetch(name, url, checksum, file)
+func (*defaultFetcher) FetchFileChecksum(name string, url string, checksum string, header http.Header) (File, error) {
+	return fetch(name, url, checksum, file, header)
 }
 
-func (*defaultFetcher) FetchDir(name string, url string) (File, error) {
-	return fetch(name, url, "", dir)
+func (*defaultFetcher) FetchDir(name string, url string, header http.Header) (File, error) {
+	return fetch(name, url, "", dir, header)
 }
 
-func (*defaultFetcher) FetchDirChecksum(name string, url string, checksum string) (File, error) {
-	return fetch(name, url, checksum, dir)
+func (*defaultFetcher) FetchDirChecksum(name string, url string, checksum string, header http.Header) (File, error) {
+	return fetch(name, url, checksum, dir, header)
+}
+
+// CreateHeader creates an http.Header from a map of key-value strings
+func CreateHeader(headers map[string]string) http.Header {
+	if headers == nil || len(headers) < 1 {
+		return nil
+	}
+
+	header := http.Header{}
+	for key, value := range headers {
+		header.Add(key, value)
+	}
+
+	return header
 }


### PR DESCRIPTION
Closes #190.

This PR adds support for custom additional headers for modules and providers upload APIs. With this users should now be able to upload files to Terralist that are not publicly available for download.