### PR TITLE
feat: added support for Gitlab groups on authentication

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -51,6 +51,7 @@ const (
 	GitLabClientIDFlag     = "gl-client-id"
 	GitLabClientSecretFlag = "gl-client-secret"
 	GitLabHostFlag         = "gl-host"
+	GitLabGroupsFlag       = "gl-groups"
 
 	OidcClientIDFlag     = "oi-client-id"
 	OidcClientSecretFlag = "oi-client-secret"
@@ -213,6 +214,10 @@ var flags = map[string]cli.Flag{
 	GitLabHostFlag: &cli.StringFlag{
 		Description:  "The GitLab host to use.",
 		DefaultValue: "gitlab.com",
+	},
+	GitLabGroupsFlag: &cli.StringFlag{
+		Description:  "The GitLab groups the user must be member. Comma separated.",
+		DefaultValue: "",
 	},
 	OidcClientIDFlag: &cli.StringFlag{
 		Description: "The OIDC Application client ID.",

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -254,6 +254,7 @@ func (s *Command) run() error {
 			ClientSecret:               flags[GitLabClientSecretFlag].(*cli.StringFlag).Value,
 			GitlabHostWithOptionalPort: flags[GitLabHostFlag].(*cli.StringFlag).Value,
 			TerralistSchemeHostAndPort: userConfig.URL,
+			Groups:                     flags[GitLabGroupsFlag].(*cli.StringFlag).Value,
 		})
 	case "oidc":
 		provider, err = authFactory.NewProvider(auth.OIDC, &oidc.Config{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,19 @@ The (self hosted) GitLab host to use. E.g. gitlab.mycompany.com:8443
 | cli | `--gl-host` |
 | env | `TERRALIST_GL_HOST` |
 
+### `gl-groups`
+
+The GitLab groups names the user must be member of. It must be comma separated with no spaces.
+
+| Name | Value |
+| --- | --- |
+| type | string |
+| required | no |
+| default | `n/a` |
+| cli | `--gl-groups` |
+| env | `TERRALIST_GL_GROUPS` |
+
+
 ### `oi-client-id`
 
 The OpenID Connect client ID.

--- a/pkg/auth/gitlab/config.go
+++ b/pkg/auth/gitlab/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	ClientSecret               string
 	TerralistSchemeHostAndPort string
 	GitlabHostWithOptionalPort string
+	Groups                     string
 }
 
 func (c *Config) SetDefaults() {}

--- a/pkg/auth/gitlab/creator.go
+++ b/pkg/auth/gitlab/creator.go
@@ -20,5 +20,6 @@ func (t *Creator) New(config auth.Configurator) (auth.Provider, error) {
 		ClientSecret:       cfg.ClientSecret,
 		GitLabOAuthBaseURL: fmt.Sprintf("https://%s/oauth", cfg.GitlabHostWithOptionalPort),
 		RedirectURL:        strings.TrimSuffix(cfg.TerralistSchemeHostAndPort, "/") + "/v1/api/auth/redirect",
+		Groups:             cfg.Groups,
 	}, nil
 }

--- a/pkg/auth/gitlab/creator.go
+++ b/pkg/auth/gitlab/creator.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"terralist/pkg/auth"
@@ -20,6 +21,8 @@ func (t *Creator) New(config auth.Configurator) (auth.Provider, error) {
 		ClientSecret:       cfg.ClientSecret,
 		GitLabOAuthBaseURL: fmt.Sprintf("https://%s/oauth", cfg.GitlabHostWithOptionalPort),
 		RedirectURL:        strings.TrimSuffix(cfg.TerralistSchemeHostAndPort, "/") + "/v1/api/auth/redirect",
-		Groups:             cfg.Groups,
+		Groups: slices.DeleteFunc(strings.Split(cfg.Groups, ","), func(e string) bool {
+			return e == ""
+		}),
 	}, nil
 }

--- a/pkg/auth/gitlab/provider.go
+++ b/pkg/auth/gitlab/provider.go
@@ -61,8 +61,17 @@ func (p *Provider) GetUserDetails(code string, user *auth.User) error {
 	if err != nil {
 		return err
 	}
-	user.Name = userdata["name"].(string)
-	user.Email = userdata["email"].(string)
+	if name, ok := userdata["name"].(string); ok {
+		user.Name = name
+	} else {
+		return fmt.Errorf("name not found in user data")
+	}
+
+	if email, ok := userdata["email"].(string); ok {
+		user.Email = email
+	} else {
+		return fmt.Errorf("email not found in user data")
+	}
 
 	// Check if the user is a member of the required groups from GitLab
 	if p.Groups != "" {

--- a/pkg/auth/gitlab/provider.go
+++ b/pkg/auth/gitlab/provider.go
@@ -24,7 +24,7 @@ type Provider struct {
 	GitLabOAuthBaseURL string
 
 	//Groups is a list of groups the user must be a member of
-	Groups string
+	Groups []string
 }
 
 type tokenResponse struct {
@@ -74,10 +74,9 @@ func (p *Provider) GetUserDetails(code string, user *auth.User) error {
 	}
 
 	// Check if the user is a member of the required groups from GitLab
-	if p.Groups != "" {
-		requiredGroups := strings.Split(p.Groups, ",")
+	if len(p.Groups) > 0 {
 		userGroups := userdata["groups"].([]interface{})
-		for _, group := range requiredGroups {
+		for _, group := range p.Groups {
 			for _, userGroup := range userGroups {
 				if group == userGroup.(string) {
 					return nil


### PR DESCRIPTION
This PR adds support for Gitlab groups, similar to GitHub teams. 

New configuration `gl-groups` was added. It accepts comma separated values with the Gitlab group names