### PR TITLE
feat: Add support for Github Enterprise Domains

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -40,6 +40,7 @@ const (
 	GitHubClientSecretFlag = "gh-client-secret"
 	GitHubOrganizationFlag = "gh-organization"
 	GitHubTeamsFlag        = "gh-teams"
+	GitHubDomainFlag       = "gh-domain"
 
 	BitBucketClientIDFlag     = "bb-client-id"
 	BitBucketClientSecretFlag = "bb-client-secret"
@@ -194,6 +195,9 @@ var flags = map[string]cli.Flag{
 	},
 	GitHubTeamsFlag: &cli.StringFlag{
 		Description: "The GitHub team slugs in CSV format to use for user validation.",
+	},
+	GitHubDomainFlag: &cli.StringFlag{
+		Description: "The GitHub base domain if you are using GitHub Enterprise. (default: 'github.com')",
 	},
 	BitBucketClientIDFlag: &cli.StringFlag{
 		Description: "The BitBucket OAuth Application client ID.",

--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -197,8 +197,8 @@ var flags = map[string]cli.Flag{
 		Description: "The GitHub team slugs in CSV format to use for user validation.",
 	},
 	GitHubDomainFlag: &cli.StringFlag{
-		Description: "The GitHub base domain if you are using GitHub Enterprise. (default: 'github.com')",
-		DefaultValue: "github.com"
+		Description:  "The GitHub base domain if you are using GitHub Enterprise. (default: 'github.com')",
+		DefaultValue: "github.com",
 	},
 	BitBucketClientIDFlag: &cli.StringFlag{
 		Description: "The BitBucket OAuth Application client ID.",

--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -198,6 +198,7 @@ var flags = map[string]cli.Flag{
 	},
 	GitHubDomainFlag: &cli.StringFlag{
 		Description: "The GitHub base domain if you are using GitHub Enterprise. (default: 'github.com')",
+		DefaultValue: "github.com"
 	},
 	BitBucketClientIDFlag: &cli.StringFlag{
 		Description: "The BitBucket OAuth Application client ID.",

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -242,6 +242,7 @@ func (s *Command) run() error {
 			ClientSecret: flags[GitHubClientSecretFlag].(*cli.StringFlag).Value,
 			Organization: flags[GitHubOrganizationFlag].(*cli.StringFlag).Value,
 			Teams:        flags[GitHubTeamsFlag].(*cli.StringFlag).Value,
+			Domain:       flags[GitHubDomainFlag].(*cli.StringFlag).Value,
 		})
 	case "bitbucket":
 		provider, err = authFactory.NewProvider(auth.BITBUCKET, &bitbucket.Config{ //nolint:forcetypeassert

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,6 +188,18 @@ The GitHub team slugs in CSV format to use for user validation. This requires `g
 | cli | `--gh-teams` |
 | env | `TERRALIST_GH_TEAMS` |
 
+### `gh-domain`
+
+The GitHub base domain if you are using GitHub Enterprise.
+
+| Name | Value |
+| --- | --- |
+| type | string |
+| required | no |
+| default | `github.com` |
+| cli | `--gh-domain` |
+| env | `TERRALIST_GH_DOMAIN` |
+
 ### `bb-client-id`
 
 The BitBucket OAuth Application client ID.

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -11,9 +11,14 @@ type Config struct {
 	ClientSecret string
 	Organization string
 	Teams        string
+	Domain       string
 }
 
-func (c *Config) SetDefaults() {}
+func (c *Config) SetDefaults() {
+	if c.Domain == "" {
+		c.Domain = "github.com"
+	}
+}
 
 func (c *Config) Validate() error {
 	if c.ClientID == "" {

--- a/pkg/auth/github/config.go
+++ b/pkg/auth/github/config.go
@@ -14,11 +14,7 @@ type Config struct {
 	Domain       string
 }
 
-func (c *Config) SetDefaults() {
-	if c.Domain == "" {
-		c.Domain = "github.com"
-	}
-}
+func (c *Config) SetDefaults() {}
 
 func (c *Config) Validate() error {
 	if c.ClientID == "" {

--- a/pkg/auth/github/creator.go
+++ b/pkg/auth/github/creator.go
@@ -15,9 +15,11 @@ func (t *Creator) New(config auth.Configurator) (auth.Provider, error) {
 	}
 
 	return &Provider{
-		ClientID:     cfg.ClientID,
-		ClientSecret: cfg.ClientSecret,
-		Organization: cfg.Organization,
-		Teams:        cfg.Teams,
+		ClientID:      cfg.ClientID,
+		ClientSecret:  cfg.ClientSecret,
+		Organization:  cfg.Organization,
+		Teams:         cfg.Teams,
+		oauthEndpoint: fmt.Sprintf("https://%s/login/oauth", cfg.Domain),
+		apiEndpoint:   fmt.Sprintf("https://api.%s", cfg.Domain),
 	}, nil
 }

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -14,10 +14,12 @@ import (
 
 // Provider is the concrete implementation of oauth.Engine.
 type Provider struct {
-	ClientID     string
-	ClientSecret string
-	Organization string
-	Teams        string
+	ClientID      string
+	ClientSecret  string
+	Organization  string
+	Teams         string
+	oauthEndpoint string
+	apiEndpoint   string
 }
 
 type tokenResponse struct {
@@ -32,8 +34,6 @@ type Team struct {
 }
 
 var (
-	oauthEndpoint = "https://github.com/login/oauth"
-	apiEndpoint   = "https://api.github.com"
 	httpClient    = &http.Client{}
 )
 
@@ -52,7 +52,7 @@ func (p *Provider) GetAuthorizeUrl(state string) string {
 
 	return fmt.Sprintf(
 		"%s/authorize?client_id=%s&state=%s&scope=%s",
-		oauthEndpoint,
+		p.oauthEndpoint,
 		p.ClientID,
 		state,
 		url.QueryEscape(scope),
@@ -96,7 +96,7 @@ func (p *Provider) GetUserDetails(code string, user *auth.User) error {
 func (p *Provider) PerformAccessTokenRequest(code string, t *tokenResponse) error {
 	accessTokenUrl := fmt.Sprintf(
 		"%s/access_token?client_id=%s&client_secret=%s&code=%s",
-		oauthEndpoint,
+		p.oauthEndpoint,
 		p.ClientID,
 		p.ClientSecret,
 		code,
@@ -123,7 +123,7 @@ func (p *Provider) PerformAccessTokenRequest(code string, t *tokenResponse) erro
 }
 
 func (p *Provider) PerformUserNameRequest(t tokenResponse) (string, error) {
-	userEndpoint := fmt.Sprintf("%s/user", apiEndpoint)
+	userEndpoint := fmt.Sprintf("%s/user", p.apiEndpoint)
 
 	req, err := http.NewRequest(http.MethodGet, userEndpoint, nil)
 	if err != nil {
@@ -160,7 +160,7 @@ func (p *Provider) PerformUserNameRequest(t tokenResponse) (string, error) {
 }
 
 func (p *Provider) PerformUserEmailRequest(t tokenResponse) (string, error) {
-	emailsEndpoint := fmt.Sprintf("%s/user/emails", apiEndpoint)
+	emailsEndpoint := fmt.Sprintf("%s/user/emails", p.apiEndpoint)
 
 	req, err := http.NewRequest(http.MethodGet, emailsEndpoint, nil)
 	if err != nil {
@@ -203,7 +203,7 @@ func (p *Provider) PerformUserEmailRequest(t tokenResponse) (string, error) {
 }
 
 func (p *Provider) PerformCheckUserMemberInOrganization(t tokenResponse) error {
-	orgEndpoint := fmt.Sprintf("%s/user/memberships/orgs/%s", apiEndpoint, p.Organization)
+	orgEndpoint := fmt.Sprintf("%s/user/memberships/orgs/%s", p.apiEndpoint, p.Organization)
 
 	req, err := http.NewRequest(http.MethodGet, orgEndpoint, nil)
 	if err != nil {
@@ -227,7 +227,7 @@ func (p *Provider) PerformCheckUserMemberInOrganization(t tokenResponse) error {
 }
 
 func (p *Provider) PerformCheckUserMemberOfTeams(t tokenResponse) error {
-	teamsEndpoint := fmt.Sprintf("%s/orgs/%s/teams", apiEndpoint, p.Organization)
+	teamsEndpoint := fmt.Sprintf("%s/orgs/%s/teams", p.apiEndpoint, p.Organization)
 
 	req, err := http.NewRequest(http.MethodGet, teamsEndpoint, nil)
 	if err != nil {

--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -34,7 +34,7 @@ type Team struct {
 }
 
 var (
-	httpClient    = &http.Client{}
+	httpClient = &http.Client{}
 )
 
 func (p *Provider) Name() string {


### PR DESCRIPTION
Like #289 already suggested, for supporting authentication against Github Enterprise instances only one additional flag is need. I added the `--gh-domain` flag with `github.com` as the default for backwards compatibility.

I already tested with the Docker setup against our company internal Github Enterprise instance and it worked fine.

Closes #289.