### PR TITLE
(enh): Enhanced logic, corrected missing README in same dir as any *.tf

### DIFF
--- a/docs/artifacts-documentation.md
+++ b/docs/artifacts-documentation.md
@@ -14,9 +14,9 @@ If you'd like Terralist to automatically generate module documentation for you, 
 
 !!! warning "If, by any means, Terralist is unable to process the module and generate the documentation for it, the upload will NOT fail. The module archive will still be uploaded without documentation and a warning log will be produced."
 
-Terralist will attempt to find a `README.md` before generating the documentation on its own. To properly detect which `README.md` file is the correct one, it will recursively traverse the directory tree. The first parent node which contains a `main.tf` file will be considered a root module, and, if this directory contains a `README.md` file, the file will be selected and used as documentation.
+Terralist will attempt to find a `README.md` before generating the documentation on its own. To properly detect which `README.md` file is the correct one, it will recursively traverse the directory tree. The first parent node which contains any `*.tf` file will be considered a root module, and, if this directory contains a `README.md` file, the file will be selected and used as documentation.
 
-!!! note "If the archive contains multiple subdirectories, and at least two of them have `main.tf` file (and a `README.md` file), it is undetermined which one will be selected as the 'root module' - depending on how the OS sorts the directories."
+!!! note "If the archive contains multiple subdirectories, and at least two of them have `*.tf` files (and a `README.md` file), it is undetermined which one will be selected as the 'root module' - depending on how the OS sorts the directories."
 
 ## Providers
 

--- a/pkg/docs/module_test.go
+++ b/pkg/docs/module_test.go
@@ -94,6 +94,25 @@ func TestGetModuleDocumentation(t *testing.T) {
 			relativePath: "subdir2",
 			expected:     `# my module2\n`,
 		},
+		{
+			title: "Module with multiple .tf files and a README.md but no main.tf because it wasn't authored that way",
+			fs: file.MustNewFS([]file.File{
+				file.NewInMemoryFile("rds.tf", []byte(`
+				resource "postgresql_role" "service_role" {}
+				`)),
+				file.NewInMemoryFile("variables.tf", []byte(`variable "test" {}`)),
+				file.NewInMemoryFile("outputs.tf", []byte(`output "test" {}`)),
+				file.NewInMemoryFile("README.md", []byte(`# My Custom Module Readme`)),
+			}),
+			expected: `# My Custom Module Readme`,
+		},
+		{
+			title: "Module with no README.md and no main.tf",
+			fs: file.MustNewFS([]file.File{
+				file.NewInMemoryFile("other.tf", []byte(`resource "null_resource" "foo" {}`)),
+			}),
+			shouldError: true,
+		},
 	}
 
 	for i, test := range testData {


### PR DESCRIPTION
For me at least, this was a bug in that if `README.md` was in the same directory as ~~`main.tf`~~ any of the `*.tf` files in the module (in this case the root of the module) then the README was ignored when registering the module in Terralist. So, I rewrote the functionality, making sure it not only corrects the issue I ran into but also passes existing Unit tests to not break other existing functionality.