### PR TITLE
feat(build): add oci labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,27 +33,49 @@ ARG COMMIT_HASH="n/a"
 ARG BUILD_TIMESTAMP="n/a"
 
 RUN go build -a -v -o terralist \
-    -ldflags="\
-      -X 'main.Version=${VERSION}' \
-      -X 'main.CommitHash=${COMMIT_HASH}' \
-      -X 'main.BuildTimestamp=${BUILD_TIMESTAMP}' \
-      -X 'main.Mode=release'" \
-    ./cmd/terralist/main.go
+  -ldflags="\
+  -X 'main.Version=${VERSION}' \
+  -X 'main.CommitHash=${COMMIT_HASH}' \
+  -X 'main.BuildTimestamp=${BUILD_TIMESTAMP}' \
+  -X 'main.Mode=release'" \
+  ./cmd/terralist/main.go
 
 FROM alpine:3.21
 
+ARG VERSION="dev"
+ARG COMMIT_HASH="n/a"
+ARG BUILD_TIMESTAMP="n/a"
+ARG IMAGE_NAME="terralist"
+ARG IMAGE_URL_BASE="github.com/terralist"
+ARG IMAGE_TAG="${VERSION}"
+ARG VCS_REF="${COMMIT_HASH}"
+
+LABEL \
+  org.opencontainers.image.created="${BUILD_TIMESTAMP}" \
+  org.opencontainers.image.description="A truly private Terraform registry" \
+  org.opencontainers.image.documentation="https://${IMAGE_URL_BASE}/${IMAGE_NAME}/-/blob/master/README.md" \
+  org.opencontainers.image.licenses="MLP-2.0" \
+  org.opencontainers.image.ref.name="${IMAGE_NAME}" \
+  org.opencontainers.image.revision="${VCS_REF}" \
+  org.opencontainers.image.source="https://${IMAGE_URL_BASE}/${IMAGE_NAME}.git" \
+  org.opencontainers.image.title="Terralist" \
+  org.opencontainers.image.url="https://${IMAGE_URL_BASE}/${IMAGE_NAME}" \
+  org.opencontainers.image.vendor="Terralist" \
+  org.opencontainers.image.version="${IMAGE_TAG}"
+
+
 RUN addgroup terralist && \
-    adduser -S -G terralist terralist && \
-    adduser terralist root && \
-    chown terralist:root /home/terralist/ && \
-    chmod g=u /home/terralist/ && \
-    chmod g=u /etc/passwd
+  adduser -S -G terralist terralist && \
+  adduser terralist root && \
+  chown terralist:root /home/terralist/ && \
+  chmod g=u /home/terralist/ && \
+  chmod g=u /etc/passwd
 
 RUN apk add --no-cache \
-      git~=2.47 \
-      libcap~=2.71 \
-      dumb-init~=1.2 \
-      su-exec~=0.2
+  git~=2.47 \
+  libcap~=2.71 \
+  dumb-init~=1.2 \
+  su-exec~=0.2
 
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY --from=backend /go/src/terralist/terralist /usr/local/bin


### PR DESCRIPTION
Adding [OCI-compliant labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to the final image stage to improve traceability, observability, and metadata compliance. These labels embed version, commit hash, source URL, and build timestamp into the image, which makes it easier to:

- Audit builds and link them back to source
- Integrate with tooling like skopeo, and SBOM generators
- Improve debugging by exposing where and when an image was built
- Support container security and compliance checks that depend on OCI metadata

These labels follow the open standard and ensure compatibility with container ecosystems (e.g., GHCR, Harbor, etc.).