### PR TITLE
feat(auth): add configurable token expiration duration

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -95,6 +95,8 @@ const (
 	CustomCompanyNameFlag = "custom-company-name"
 
 	AuthorizedUsersFlag = "authorized-users"
+
+	AuthTokenExpirationFlag = "auth-token-expiration"
 )
 
 var flags = map[string]cli.Flag{
@@ -349,5 +351,11 @@ var flags = map[string]cli.Flag{
 
 	AuthorizedUsersFlag: &cli.StringFlag{
 		Description: "The list of users that are authorized to access the Terralist instance (comma separated).",
+	},
+
+	AuthTokenExpirationFlag: &cli.StringFlag{
+		Description:  "The duration for which auth tokens remain valid.",
+		Choices:      []string{"1d", "1w", "1m", "1y", "never"},
+		DefaultValue: "1d",
 	},
 }

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -182,6 +182,7 @@ func (s *Command) run() error {
 		ProvidersAnonymousRead: flags[ProvidersAnonymousReadFlag].(*cli.BoolFlag).Value,
 		Home:                   flags[HomeFlag].(*cli.PathFlag).Value,
 		AuthorizedUsers:        flags[AuthorizedUsersFlag].(*cli.StringFlag).Value,
+		AuthTokenExpiration:    flags[AuthTokenExpirationFlag].(*cli.StringFlag).Value,
 	}
 
 	if s.RunningMode == "debug" {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,19 @@ Comma separated list of users authorized to access the settings page. If empty, 
 | cli | `--authorized-users` |
 | env | `TERRALIST_AUTHORIZED_USERS` |
 
+### `auth-token-expiration`
+
+The duration for which auth tokens remain valid.
+
+| Name | Value |
+| --- | --- |
+| type | select |
+| choices | `1d`, `1w`, `1m`, `1y`, `never` |
+| required | no |
+| default | `1d` |
+| cli | `--auth-token-expiration` |
+| env | `TERRALIST_AUTH_TOKEN_EXPIRATION` |
+
 ### `oauth-provider`
 
 The OAuth 2.0 provider.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -13,4 +13,5 @@ type UserConfig struct {
 	ModulesAnonymousRead   bool   `mapstructure:"modules-anonymous-read"`
 	ProvidersAnonymousRead bool   `mapstructure:"providers-anonymous-read"`
 	AuthorizedUsers        string `mapstructure:"authorized-users"`
+	AuthTokenExpiration    string `mapstructure:"auth-token-expiration"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,12 +105,16 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	salt, _ := random.String(32)
 	exchangeKey, _ := random.String(32)
 
+	// Parse token expiration duration
+	tokenExpirationSeconds := services.ParseTokenExpiration(userConfig.AuthTokenExpiration)
+
 	loginService := &services.DefaultLoginService{
 		Provider: config.Provider,
 		JWT:      jwtManager,
 
-		EncryptSalt:     salt,
-		CodeExchangeKey: exchangeKey,
+		EncryptSalt:         salt,
+		CodeExchangeKey:     exchangeKey,
+		TokenExpirationSecs: tokenExpirationSeconds,
 	}
 
 	loginController := &controllers.DefaultLoginController{

--- a/internal/server/services/login.go
+++ b/internal/server/services/login.go
@@ -10,10 +10,6 @@ import (
 	"terralist/pkg/auth/jwt"
 )
 
-var (
-	tokenExpirationInSeconds = 24 * 60 * 60
-)
-
 // LoginService describes a service that holds the business logic for authentication.
 type LoginService interface {
 	// Authorize initiates the OAUTH 2.0 process, computing the provider authorize URL.
@@ -35,8 +31,27 @@ type DefaultLoginService struct {
 	Provider auth.Provider
 	JWT      jwt.JWT
 
-	EncryptSalt     string
-	CodeExchangeKey string
+	EncryptSalt         string
+	CodeExchangeKey     string
+	TokenExpirationSecs int
+}
+
+// ParseTokenExpiration converts duration string to seconds
+func ParseTokenExpiration(duration string) int {
+	switch duration {
+	case "1d":
+		return 24 * 60 * 60 // 1 day (default)
+	case "1w":
+		return 7 * 24 * 60 * 60 // 1 week
+	case "1m":
+		return 30 * 24 * 60 * 60 // 1 month (30 days)
+	case "1y":
+		return 365 * 24 * 60 * 60 // 1 year
+	case "never":
+		return 0 // 0 means no expiration
+	default:
+		return 24 * 60 * 60 // Default to 1 day
+	}
 }
 
 func (s *DefaultLoginService) Authorize(state oauth.Payload) (string, oauth.Error) {
@@ -82,7 +97,7 @@ func (s *DefaultLoginService) ValidateToken(components *oauth.CodeComponents, ve
 	t, err := s.JWT.Build(auth.User{
 		Name:  components.UserName,
 		Email: components.UserEmail,
-	}, tokenExpirationInSeconds)
+	}, s.TokenExpirationSecs)
 	if err != nil {
 		return nil, oauth.WrapError(err, oauth.InvalidRequest)
 	}
@@ -91,6 +106,6 @@ func (s *DefaultLoginService) ValidateToken(components *oauth.CodeComponents, ve
 		AccessToken:  t,
 		TokenType:    "bearer",
 		RefreshToken: "",
-		ExpiresIn:    tokenExpirationInSeconds,
+		ExpiresIn:    s.TokenExpirationSecs,
 	}, nil
 }

--- a/internal/server/services/login_test.go
+++ b/internal/server/services/login_test.go
@@ -129,12 +129,59 @@ func TestRedirect(t *testing.T) {
 	})
 }
 
+func TestParseTokenExpiration(t *testing.T) {
+	Convey("Subject: Parse token expiration durations", t, func() {
+		Convey("When parsing '1d'", func() {
+			result := ParseTokenExpiration("1d")
+			Convey("Should return 1 day in seconds", func() {
+				So(result, ShouldEqual, 24*60*60)
+			})
+		})
+
+		Convey("When parsing '1w'", func() {
+			result := ParseTokenExpiration("1w")
+			Convey("Should return 1 week in seconds", func() {
+				So(result, ShouldEqual, 7*24*60*60)
+			})
+		})
+
+		Convey("When parsing '1m'", func() {
+			result := ParseTokenExpiration("1m")
+			Convey("Should return 1 month (30 days) in seconds", func() {
+				So(result, ShouldEqual, 30*24*60*60)
+			})
+		})
+
+		Convey("When parsing '1y'", func() {
+			result := ParseTokenExpiration("1y")
+			Convey("Should return 1 year in seconds", func() {
+				So(result, ShouldEqual, 365*24*60*60)
+			})
+		})
+
+		Convey("When parsing 'never'", func() {
+			result := ParseTokenExpiration("never")
+			Convey("Should return 0 (no expiration)", func() {
+				So(result, ShouldEqual, 0)
+			})
+		})
+
+		Convey("When parsing an unknown value", func() {
+			result := ParseTokenExpiration("unknown")
+			Convey("Should return 1 day as default", func() {
+				So(result, ShouldEqual, 24*60*60)
+			})
+		})
+	})
+}
+
 func TestValidateToken(t *testing.T) {
 	Convey("Subject: Validate a token", t, func() {
 		mockJWT := mockJWT.NewJWT(t)
 
 		loginService := &DefaultLoginService{
-			JWT: mockJWT,
+			JWT:                 mockJWT,
+			TokenExpirationSecs: 24 * 60 * 60, // 1 day default
 		}
 
 		Convey("Given the code components and the code verifier", func() {


### PR DESCRIPTION
Add support for configurable auth token expiration with enum values:
- 1d (1 day, default)
- 1w (1 week)
- 1m (1 month)
- 1y (1 year)
- never (no expiration)

Changes:
- Add --auth-token-expiration flag with validation
- Support environment variable TERRALIST_AUTH_TOKEN_EXPIRATION
- Update login service to use configurable expiration
- Add comprehensive tests for ParseTokenExpiration function
- Update documentation with new configuration option

Replaces hardcoded 24-hour token expiration with user-configurable option defaulting to 1 day for better security posture.