### PR TITLE
chore(deps): Downgrade svelte-system-info to v1.0.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "svelte-eslint-parser": "^1.2.0",
     "svelte-markdown": "^0.4.1",
     "svelte-spa-router": "^4.0.1",
-    "svelte-system-info": "1.0.3",
+    "svelte-system-info": "1.0.1",
     "svelte-use-click-outside": "^1.0.0",
     "tailwindcss": "^3.4.17",
     "tslib": "^2.8.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2465,10 +2465,10 @@ svelte-spa-router@^4.0.1:
   dependencies:
     regexparam "2.0.2"
 
-svelte-system-info@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/svelte-system-info/-/svelte-system-info-1.0.3.tgz#6b3bc79ad195222c41b286ab9f3ee9ba14a74aee"
-  integrity sha512-Hasj4Es72KU7C3iIW6Yzjaek8d5iVAMk+ybRq7pIu4gqv3MMYqrvW0ViknUrI1eDXBCkLlGxfi0i2MAxQAzN2g==
+svelte-system-info@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/svelte-system-info/-/svelte-system-info-1.0.1.tgz#08bcbc4ba79d4d9449211b5a4104e32dd98c9347"
+  integrity sha512-b6EbVPGEXwTXQ5tD+6aOOHzjLOyhYmihK2cN+BH4XNfMx8Va84XqpIEt0PouSZ1xYe+aHiaOe524K4VoPiLceQ==
   dependencies:
     tslib "^2.6.2"
 


### PR DESCRIPTION
During frontend build, `vite-plugin-svelte` reports the following warning:

```
[vite-plugin-svelte] WARNING: The following packages use a svelte resolve configuration in package.json that has conflicting results and is going to cause problems future.

svelte-system-info@1.0.3

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#conflicts-in-svelte-resolve for details.
```

After further investigations, I noticed that the package is indeed updated to 1.0.3 on npmjs.org [[1](https://www.npmjs.com/package/svelte-system-info)], but the source code is only tagged up to 1.0.1 [[2](https://github.com/rozek/svelte-system-info)] (as of now, August 27, 2025).