### PR TITLE
refactor!: namespace group references under group: prefix

### DIFF
--- a/docs/user-guide/rbac-configuration.md
+++ b/docs/user-guide/rbac-configuration.md
@@ -31,9 +31,9 @@ The model syntax is based on [Casbin](https://casbin.org/docs/overview) and high
 
 **Group**: Used to assign users or groups to internal roles.
 
-Syntax: `g, <username>/<useremail>/role:<group>, <role>`
+Syntax: `g, <username>/<useremail>/group:<group>, <role>`
 
-- `<username>/<useremail>/role:<group>`: The entity to whom the role will be assigned. Depending on the OAuth provider implementation those values can represent different things; Usually, the `username` refers to the `sub` claim, while the `useremail` and `group` refers to a custom claims, which might not even be supported by the provider you are using. Check the OAuth provider documentation for more details.
+- `<username>/<useremail>/group:<group>`: The entity to whom the role will be assigned. Depending on the OAuth provider implementation those values can represent different things; Usually, the `username` refers to the `sub` claim, while the `useremail` and `group` refers to a custom claims, which might not even be supported by the provider you are using. Check the OAuth provider documentation for more details.
 - `<role>`: The internal role to which the entity will be assigned.
 
 <!-- TODO: Add proper oauth provider docs -->
@@ -49,9 +49,9 @@ Below is a table that defines claims meaning for each OAuth provider.
 
 **Policy**: Allows to assign permissions to an entity.
 
-Syntax: `p, role:<role>/<username>/<useremail>/role:<group>, <resource>, <action>, <object>, <effect>`
+Syntax: `p, role:<role>/<username>/<useremail>/group:<group>, <resource>, <action>, <object>, <effect>`
 
-- `role:<role>/<username>/<useremail>/role:<group>`: The entity to whom the policy will be assigned
+- `role:<role>/<username>/<useremail>/group:<group>`: The entity to whom the policy will be assigned
 - `<resource>`<sup>*</sup>: The type of resource on which the action is performed. Can be one of: `modules`, `providers`, `authorities`, `api-keys`, `settings`. Supports glob matching.
 - `<action>`<sup>*</sup>: The operation that is being performed on the resource. Can be one of: `get`, `create`, `update`, `delete`. Supports glob matching.
 - `<object>`<sup>*</sup>: The object identifier representing the resource on which the action is performed. Supports glob matching. Depending on the resource, the object's format will vary.
@@ -129,8 +129,8 @@ p, role:authority-admin, authorities, *, *, allow
 Then map identity claims (user/group/email) to those roles:
 
 ```csv
-g, role:SSOAWS_PLATFORM, role:authority-admin
-g, role:SSOAWS_ENGINEERING, role:authority-reader
+g, group:SSOAWS_PLATFORM, role:authority-admin
+g, group:SSOAWS_ENGINEERING, role:authority-reader
 ```
 
 ## Settings Page Access With RBAC

--- a/docs/user-guide/saml-configuration.md
+++ b/docs/user-guide/saml-configuration.md
@@ -369,9 +369,9 @@ SAML integrates with Terralist's RBAC system. Configure user roles based on SAML
 
 ```bash
 # In your RBAC policy file
-g, engineering@company.com, role:admin
-g, developers@company.com, role:contributor
-g, viewers@company.com, role:readonly
+g, group:engineering@company.com, role:admin
+g, group:developers@company.com, role:contributor
+g, group:viewers@company.com, role:readonly
 ```
 
 The `saml-groups-attribute` configuration determines which SAML attribute contains the group information.

--- a/pkg/rbac/enforcer.go
+++ b/pkg/rbac/enforcer.go
@@ -241,7 +241,7 @@ func (e *Enforcer) Protect(subject auth.User, resource, action, object string) e
 		append(
 			[]string{subject.Name, subject.Email},
 			lo.Map(subject.Groups, func(group string, _ int) string {
-				return fmt.Sprintf("role:%s", group)
+				return fmt.Sprintf("group:%s", group)
 			})...,
 		),
 	)

--- a/pkg/rbac/enforcer_test.go
+++ b/pkg/rbac/enforcer_test.go
@@ -174,7 +174,7 @@ func TestProtect_UsesGroupSubjects(t *testing.T) {
 	t.Parallel()
 
 	policy := `
-g, role:engineering, role:developer
+g, group:engineering, role:developer
 p, role:developer, authorities, create, *, allow
 `
 


### PR DESCRIPTION
This PR changes RBAC group references to use a dedicated `group:` prefix instead of `role:`, so group names cannot collide with usernames or with built-in/custom role names.

## Breaking changes

Server-side RBAC policies that reference SAML/OAuth groups must now use the `group:` prefix instead of `role:`. For example, a mapping previously written as `g, role:ENGINEERING_ADMINS, role:admin` becomes `g, group:ENGINEERING_ADMINS, role:admin`. Policies that reference only usernames, emails, or roles are unaffected. Update any group `g`/`p` entries in your policy file when upgrading.

Ref #880.