### PR TITLE
fix: Invalid default VCS Provider; add tests

### DIFF
--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -501,11 +501,6 @@ func (s *Command) run() error {
 			AppPrivateKeyPath: flags[GitHubAppPrivateKeyPathFlag].(*cli.StringFlag).Value,
 			BaseURL:           flags[GitHubBaseURLFlag].(*cli.StringFlag).Value,
 		})
-	default:
-		raw := flags[VcsProviderFlag].(*cli.StringFlag).Value //nolint:forcetypeassert
-		if raw != "" {
-			return fmt.Errorf("invalid VCS provider: %s", raw)
-		}
 	}
 	if err != nil {
 		return err

--- a/pkg/cli/bool_flag_test.go
+++ b/pkg/cli/bool_flag_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+var _ Flag = (*BoolFlag)(nil)
+
+func TestBoolFlag_IsHidden_False(t *testing.T) {
+	flag := &BoolFlag{}
+	if flag.IsHidden() {
+		t.Fatal("expected hidden false")
+	}
+}
+
+func TestBoolFlag_IsHidden_True(t *testing.T) {
+	flag := &BoolFlag{Hidden: true}
+	if !flag.IsHidden() {
+		t.Fatal("expected hidden true")
+	}
+}
+
+func TestBoolFlag_Set_NilUsesDefault(t *testing.T) {
+	flag := BoolFlag{DefaultValue: true}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != true {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_NilDoesNotMarkSet(t *testing.T) {
+	flag := BoolFlag{DefaultValue: true}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false")
+	}
+}
+
+func TestBoolFlag_Set_True(t *testing.T) {
+	flag := BoolFlag{DefaultValue: false}
+	if err := flag.Set(true); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != true {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_TrueMarksSet(t *testing.T) {
+	flag := BoolFlag{DefaultValue: false}
+	if err := flag.Set(true); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsSet() {
+		t.Error("expected IsSet true")
+	}
+}
+
+func TestBoolFlag_Set_FalseYieldsFalse(t *testing.T) {
+	flag := BoolFlag{DefaultValue: true}
+	if err := flag.Set(false); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != false {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_FalseMarksSetFalseWhenDifferentFromDefault(t *testing.T) {
+	flag := BoolFlag{DefaultValue: true}
+	if err := flag.Set(false); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false for false value")
+	}
+}
+
+func TestBoolFlag_Set_FalseMatchesDefault(t *testing.T) {
+	flag := BoolFlag{DefaultValue: false}
+	if err := flag.Set(false); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != false {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_FromString(t *testing.T) {
+	flag := BoolFlag{}
+	if err := flag.Set("true"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != true {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_InvalidString(t *testing.T) {
+	flag := BoolFlag{}
+	if err := flag.Set("invalid"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBoolFlag_Set_WrongType(t *testing.T) {
+	flag := BoolFlag{}
+	if err := flag.Set(1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBoolFlag_Set_Environment(t *testing.T) {
+	t.Setenv("TL_BOOL_FLAG", "true")
+	flag := BoolFlag{}
+	if err := flag.Set("${TL_BOOL_FLAG}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != true {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Set_EnvironmentDefault(t *testing.T) {
+	os.Unsetenv("TL_BOOL_FLAG_MISSING")
+	flag := BoolFlag{}
+	if err := flag.Set("${TL_BOOL_FLAG_MISSING:true}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != true {
+		t.Errorf("Value = %v", flag.Value)
+	}
+}
+
+func TestBoolFlag_Format(t *testing.T) {
+	flag := BoolFlag{Description: "debug", DefaultValue: true}
+	got := flag.Format()
+	if !strings.Contains(got, "debug") || !strings.Contains(got, "true") {
+		t.Errorf("Format() = %q", got)
+	}
+}
+
+func TestBoolFlag_Validate_RequiredNotSet(t *testing.T) {
+	flag := BoolFlag{Required: true}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected required error")
+	}
+}
+
+func TestBoolFlag_Validate_RequiredSet(t *testing.T) {
+	flag := BoolFlag{Required: true}
+	if err := flag.Set(true); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBoolFlag_Validate_Optional(t *testing.T) {
+	flag := BoolFlag{}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/cli/int_flag_test.go
+++ b/pkg/cli/int_flag_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+var _ Flag = (*IntFlag)(nil)
+
+func TestIntFlag_IsHidden_False(t *testing.T) {
+	flag := &IntFlag{}
+	if flag.IsHidden() {
+		t.Fatal("expected hidden false")
+	}
+}
+
+func TestIntFlag_IsHidden_True(t *testing.T) {
+	flag := &IntFlag{Hidden: true}
+	if !flag.IsHidden() {
+		t.Fatal("expected hidden true")
+	}
+}
+
+func TestIntFlag_Set_NilUsesDefault(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 7 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_NilDoesNotMarkSet(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false")
+	}
+}
+
+func TestIntFlag_Set_Int(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(9); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 9 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_IntMarksSet(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(9); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsSet() {
+		t.Error("expected IsSet true")
+	}
+}
+
+func TestIntFlag_Set_ZeroYieldsZero(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(0); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 0 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_ZeroMarksSetFalseWhenDifferentFromDefault(t *testing.T) {
+	flag := IntFlag{DefaultValue: 7}
+	if err := flag.Set(0); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false for zero")
+	}
+}
+
+func TestIntFlag_Set_ZeroMatchesDefault(t *testing.T) {
+	flag := IntFlag{DefaultValue: 0}
+	if err := flag.Set(0); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 0 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_FromString(t *testing.T) {
+	flag := IntFlag{}
+	if err := flag.Set("42"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 42 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_FromStringMarksSet(t *testing.T) {
+	flag := IntFlag{}
+	if err := flag.Set("42"); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsSet() {
+		t.Error("expected IsSet true")
+	}
+}
+
+func TestIntFlag_Set_InvalidString(t *testing.T) {
+	flag := IntFlag{}
+	if err := flag.Set("nope"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIntFlag_Set_WrongType(t *testing.T) {
+	flag := IntFlag{}
+	if err := flag.Set(true); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIntFlag_Set_Environment(t *testing.T) {
+	t.Setenv("TL_INT_FLAG", "11")
+	flag := IntFlag{}
+	if err := flag.Set("${TL_INT_FLAG}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 11 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Set_EnvironmentDefault(t *testing.T) {
+	os.Unsetenv("TL_INT_FLAG_MISSING")
+	flag := IntFlag{}
+	if err := flag.Set("${TL_INT_FLAG_MISSING:5}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != 5 {
+		t.Errorf("Value = %d", flag.Value)
+	}
+}
+
+func TestIntFlag_Format_WithoutDefault(t *testing.T) {
+	flag := IntFlag{Description: "port"}
+	if flag.Format() != "port" {
+		t.Errorf("Format() = %q", flag.Format())
+	}
+}
+
+func TestIntFlag_Format_WithDefault(t *testing.T) {
+	flag := IntFlag{Description: "port", DefaultValue: 8080}
+	got := flag.Format()
+	if !strings.Contains(got, "port") || !strings.Contains(got, "8080") {
+		t.Errorf("Format() = %q", got)
+	}
+}
+
+func TestIntFlag_Validate_RequiredNotSet(t *testing.T) {
+	flag := IntFlag{Required: true}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected required error")
+	}
+}
+
+func TestIntFlag_Validate_RequiredSet(t *testing.T) {
+	flag := IntFlag{Required: true}
+	if err := flag.Set(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntFlag_Validate_Optional(t *testing.T) {
+	flag := IntFlag{}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/cli/path_flag_test.go
+++ b/pkg/cli/path_flag_test.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var _ Flag = (*PathFlag)(nil)
+
+func TestPathFlag_IsHidden_False(t *testing.T) {
+	flag := &PathFlag{}
+	if flag.IsHidden() {
+		t.Fatal("expected hidden false")
+	}
+}
+
+func TestPathFlag_IsHidden_True(t *testing.T) {
+	flag := &PathFlag{Hidden: true}
+	if !flag.IsHidden() {
+		t.Fatal("expected hidden true")
+	}
+}
+
+func TestPathFlag_Set_NilUsesDefault(t *testing.T) {
+	flag := PathFlag{DefaultValue: "/tmp"}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "/tmp" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestPathFlag_Set_NilDoesNotMarkSet(t *testing.T) {
+	flag := PathFlag{DefaultValue: "/tmp"}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false")
+	}
+}
+
+func TestPathFlag_Set_Absolute(t *testing.T) {
+	flag := PathFlag{}
+	if err := flag.Set("/var/lib/data"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "/var/lib/data" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestPathFlag_Set_AbsoluteMarksSet(t *testing.T) {
+	flag := PathFlag{}
+	if err := flag.Set("/var/lib/data"); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsSet() {
+		t.Error("expected IsSet true")
+	}
+}
+
+func TestPathFlag_Set_EmptyYieldsEmpty(t *testing.T) {
+	flag := PathFlag{DefaultValue: "/tmp"}
+	if err := flag.Set(""); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestPathFlag_Set_EmptyMarksSetFalseWhenDifferentFromDefault(t *testing.T) {
+	flag := PathFlag{DefaultValue: "/tmp"}
+	if err := flag.Set(""); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false for empty path")
+	}
+}
+
+func TestPathFlag_Set_WrongType(t *testing.T) {
+	flag := PathFlag{}
+	if err := flag.Set(1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPathFlag_Set_HomeTilde(t *testing.T) {
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := PathFlag{}
+	if err := flag.Set("~"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != usr.HomeDir {
+		t.Errorf("Value = %q, want %q", flag.Value, usr.HomeDir)
+	}
+}
+
+func TestPathFlag_Set_HomeTildePath(t *testing.T) {
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := PathFlag{}
+	if err := flag.Set("~/data"); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(usr.HomeDir, "data")
+	if flag.Value != want {
+		t.Errorf("Value = %q, want %q", flag.Value, want)
+	}
+}
+
+func TestPathFlag_Set_Dot(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := PathFlag{}
+	if err := flag.Set("."); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != cwd {
+		t.Errorf("Value = %q, want %q", flag.Value, cwd)
+	}
+}
+
+func TestPathFlag_Set_DotSlash(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := PathFlag{}
+	if err := flag.Set("./subdir"); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(cwd, "subdir")
+	if flag.Value != want {
+		t.Errorf("Value = %q, want %q", flag.Value, want)
+	}
+}
+
+func TestPathFlag_Set_Environment(t *testing.T) {
+	t.Setenv("TL_PATH_FLAG", "/opt/terralist")
+	flag := PathFlag{}
+	if err := flag.Set("${TL_PATH_FLAG}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "/opt/terralist" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestPathFlag_Format(t *testing.T) {
+	flag := PathFlag{Description: "config", DefaultValue: "/etc/app"}
+	got := flag.Format()
+	if !strings.Contains(got, "config") || !strings.Contains(got, "/etc/app") {
+		t.Errorf("Format() = %q", got)
+	}
+}
+
+func TestPathFlag_Validate_RequiredNotSet(t *testing.T) {
+	flag := PathFlag{Required: true}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected required error")
+	}
+}
+
+func TestPathFlag_Validate_RequiredSet(t *testing.T) {
+	flag := PathFlag{Required: true}
+	if err := flag.Set("/abs"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPathFlag_Validate_OptionalEmpty(t *testing.T) {
+	flag := PathFlag{}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPathFlag_Validate_Relative(t *testing.T) {
+	flag := PathFlag{Value: "rel"}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected non-absolute error")
+	}
+}

--- a/pkg/cli/string_flag.go
+++ b/pkg/cli/string_flag.go
@@ -85,6 +85,10 @@ func (t *StringFlag) Validate() error {
 		return fmt.Errorf("required but not set")
 	}
 
+	if !t.Required && t.Value == "" {
+		return nil
+	}
+
 	if len(t.Choices) > 0 {
 		if !slices.Contains(t.Choices, t.Value) {
 			options := strings.Join(t.Choices, ", ")

--- a/pkg/cli/string_flag_test.go
+++ b/pkg/cli/string_flag_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+var _ Flag = (*StringFlag)(nil)
+
+func TestStringFlag_IsHidden_False(t *testing.T) {
+	flag := &StringFlag{}
+	if flag.IsHidden() {
+		t.Fatal("expected hidden false")
+	}
+}
+
+func TestStringFlag_IsHidden_True(t *testing.T) {
+	flag := &StringFlag{Hidden: true}
+	if !flag.IsHidden() {
+		t.Fatal("expected hidden true")
+	}
+}
+
+func TestStringFlag_Set_NilUsesDefault(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "fallback" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestStringFlag_Set_NilDoesNotMarkSet(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set(nil); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false")
+	}
+}
+
+func TestStringFlag_Set_String(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "hello" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestStringFlag_Set_StringMarksSet(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if !flag.IsSet() {
+		t.Error("expected IsSet true")
+	}
+}
+
+func TestStringFlag_Set_EmptyYieldsEmpty(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set(""); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "" {
+		t.Errorf("Value = %q, want empty", flag.Value)
+	}
+}
+
+func TestStringFlag_Set_EmptyMarksSetFalseWhenDifferentFromDefault(t *testing.T) {
+	flag := StringFlag{DefaultValue: "fallback"}
+	if err := flag.Set(""); err != nil {
+		t.Fatal(err)
+	}
+	if flag.IsSet() {
+		t.Error("expected IsSet false for empty string")
+	}
+}
+
+func TestStringFlag_Set_EmptyMatchesDefault(t *testing.T) {
+	flag := StringFlag{DefaultValue: ""}
+	if err := flag.Set(""); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestStringFlag_Set_WrongType(t *testing.T) {
+	flag := StringFlag{}
+	if err := flag.Set(42); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStringFlag_Set_ValidChoice(t *testing.T) {
+	flag := StringFlag{Choices: []string{"a", "b"}}
+	if err := flag.Set("a"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStringFlag_Set_InvalidChoice(t *testing.T) {
+	flag := StringFlag{Choices: []string{"a", "b"}}
+	if err := flag.Set("c"); err == nil {
+		t.Fatal("expected error for invalid choice")
+	}
+}
+
+func TestStringFlag_Set_Environment(t *testing.T) {
+	t.Setenv("TL_STRING_FLAG", "from-env")
+	flag := StringFlag{}
+	if err := flag.Set("${TL_STRING_FLAG}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "from-env" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestStringFlag_Set_EnvironmentDefault(t *testing.T) {
+	os.Unsetenv("TL_STRING_FLAG_MISSING")
+	flag := StringFlag{}
+	if err := flag.Set("${TL_STRING_FLAG_MISSING:def}"); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Value != "def" {
+		t.Errorf("Value = %q", flag.Value)
+	}
+}
+
+func TestStringFlag_Format_Description(t *testing.T) {
+	flag := StringFlag{Description: "mode"}
+	if !strings.Contains(flag.Format(), "mode") {
+		t.Errorf("Format() = %q", flag.Format())
+	}
+}
+
+func TestStringFlag_Format_Choices(t *testing.T) {
+	flag := StringFlag{Description: "mode", Choices: []string{"a", "b"}}
+	got := flag.Format()
+	if !strings.Contains(got, "Options:") || !strings.Contains(got, "a, b") {
+		t.Errorf("Format() = %q", got)
+	}
+}
+
+func TestStringFlag_Format_Default(t *testing.T) {
+	flag := StringFlag{Description: "mode", DefaultValue: "a"}
+	if !strings.Contains(flag.Format(), `default "a"`) {
+		t.Errorf("Format() = %q", flag.Format())
+	}
+}
+
+func TestStringFlag_Validate_RequiredNotSet(t *testing.T) {
+	flag := StringFlag{Required: true}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected required error")
+	}
+}
+
+func TestStringFlag_Validate_RequiredSet(t *testing.T) {
+	flag := StringFlag{Required: true}
+	if err := flag.Set("ok"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStringFlag_Validate_OptionalEmpty(t *testing.T) {
+	flag := StringFlag{}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStringFlag_Validate_OptionalEmptyChoice(t *testing.T) {
+	flag := StringFlag{Choices: []string{"a", "b"}}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStringFlag_Validate_InvalidChoice(t *testing.T) {
+	flag := StringFlag{Choices: []string{"a", "b"}, Value: "z"}
+	if err := flag.Validate(); err == nil {
+		t.Fatal("expected invalid choice")
+	}
+}
+
+func TestStringFlag_Validate_ValidChoice(t *testing.T) {
+	flag := StringFlag{Choices: []string{"a", "b"}, Value: "a"}
+	if err := flag.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fix scenario where unset vcs-provider flag results in an error due to the flag value being an invalid choice. This is done by ignoring an unset string flag if not required when the value is an empty string. Previously, during flag value validation, string flags would be checked for choice validity even if they were unset and not required. Now, unset string flags with choices do not result in errors if not required.

This PR also adds tests and fixes some suspected bugs in flag parsing. These bugs relate to scenarios where the flag value is set to the zero value for the type (i.e. false for bool, empty string for string and path, and zero for int). 

Fixes #898 